### PR TITLE
Added a new helper: mail-to

### DIFF
--- a/src/hiccup/page_helpers.clj
+++ b/src/hiccup/page_helpers.clj
@@ -93,6 +93,13 @@
   [url & content]
   [:a {:href url} content])
 
+(defelem mail-to
+  "Wraps some content in a HTML hyperlink with the supplied e-mail
+  address. If no content provided use the e-mail address as content."
+  [e-mail & [content]]
+  [:a {:href (str "mailto:" e-mail)}
+   (or content e-mail)])
+
 (defelem unordered-list
   "Wrap a collection in an unordered list"
   [coll]


### PR DESCRIPTION
Hi, I've added a new helper: mail-to, it's like link-to but add "mailto:" to the href and if there's only one argument it use it as the content.
