### PR TITLE
Proposed change to make hiccup.form-helpers/text-area escape its content.

### DIFF
--- a/src/hiccup/form_helpers.clj
+++ b/src/hiccup/form_helpers.clj
@@ -2,7 +2,7 @@
   "Functions for generating HTML forms and input fields."
   (:use
      clojure.contrib.java-utils
-     [hiccup.core :only (defelem)]))
+     [hiccup.core :only (defelem escape-html)]))
 
 (def *group* [])
 
@@ -92,7 +92,7 @@
   ([name] (text-area name nil))
   ([name value]
     [:textarea {:name (make-name name), :id (make-id name)}
-       value]))
+      (escape-html value)]))
 
 (defelem file-upload
   "Creates a file upload input."

--- a/test/hiccup/test/form_helpers.clj
+++ b/test/hiccup/test/form_helpers.clj
@@ -79,6 +79,10 @@
   (is (= (html (text-area {:class "classy"} :foo "bar"))
          "<textarea class=\"classy\" id=\"foo\" name=\"foo\">bar</textarea>")))
 
+(deftest test-text-area-escapes
+  (is (= (html (text-area :foo "bar</textarea>"))
+         "<textarea id=\"foo\" name=\"foo\">bar&lt;/textarea&gt;</textarea>")))
+
 (deftest test-file-field
   (is (= (html (file-upload :foo))
          "<input id=\"foo\" name=\"foo\" type=\"file\" />")))


### PR DESCRIPTION
All the form element generating functions in form-helpers escape their values, except for text-area. There are 2 issues with this:
1. if the value of the field contains a <., > or &, the resulting output isn't valid xhtml.
2. if the value contains a "</textarea>" substring, the rest of the value will "break out" of the field when rendered.

The change in this request always escapes the content of the text-area value. A test is included.

Cheers,
Joost Diepenmaat.
