### PR TITLE
Removing dependencies on old contrib

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,12 +2,10 @@
   :description "A fast library for rendering HTML in Clojure"
   :url "http://github.com/weavejester/hiccup"
   :dependencies
-    [[org.clojure/clojure "1.2.0"]
-     [org.clojure/clojure-contrib "1.2.0"]]
-  :dev-dependencies 
-    [[autodoc "0.7.1" :exclusions [org.clojure/clojure
-                                   org.clojure/clojure-contrib]]]
-  :autodoc 
+    [[org.clojure/clojure "1.2.0"]]
+  :dev-dependencies [[org.clojure/clojure-contrib "1.2.0"]
+                     [autodoc "0.7.1" :exclusions [org.clojure/clojure
+                                                   org.clojure/clojure-contrib]]]
     {:name "Hiccup"
      :description "A fast library for rendering HTML in Clojure."
      :copyright "Copyright 2009-2010 James Reeves"

--- a/src/hiccup/form_helpers.clj
+++ b/src/hiccup/form_helpers.clj
@@ -1,7 +1,6 @@
 (ns hiccup.form-helpers
   "Functions for generating HTML forms and input fields."
-  (:use clojure.contrib.java-utils
-        [hiccup.core :only (defelem escape-html resolve-uri)]))
+  (:use [hiccup.core :only (defelem escape-html resolve-uri as-str)]))
 
 (def *group* [])
 

--- a/src/hiccup/page_helpers.clj
+++ b/src/hiccup/page_helpers.clj
@@ -1,9 +1,8 @@
 (ns hiccup.page-helpers
   "Functions for generating various common elements."
   (:import java.net.URLEncoder)
-  (:use [hiccup.core :only (defelem html resolve-uri)]
-        [clojure.contrib.java-utils :only (as-str)]
-        [clojure.contrib.str-utils :only (str-join)]))
+  (:use [hiccup.core :only (defelem html resolve-uri as-str)])
+  (:require [clojure.string :as str]))
 
 (def doctype
   {:html4
@@ -119,7 +118,7 @@
   "Turn a map of parameters into a urlencoded string."
   [params]
   (letfn [(encode [s] (URLEncoder/encode (as-str s)))]
-    (str-join "&"
+    (str/join "&"
       (for [[k v] params]
         (str (encode k) "=" (encode v))))))
 


### PR DESCRIPTION
This will take make hiccup no longer rely on c.c for normal development.  I left c.c in as a dev dependency because of mock test adapter.  It will help us out in a huge way if you could push this in and release a new version.  
