### PR TITLE
parameter's character encoding

### DIFF
--- a/src/hiccup/page_helpers.clj
+++ b/src/hiccup/page_helpers.clj
@@ -114,13 +114,28 @@
   ([src]     [:image {:src (resolve-uri src)}])
   ([src alt] [:image {:src (resolve-uri src), :alt alt}]))
 
+(def
+ #^{:doc "Name of the default encoding to use .
+  Default is UTF-8."
+    :tag "java.lang.String"}
+ *default-encoding* "UTF-8")
+
+(defmacro with-encoding
+  "Evaluates expr with encoding."
+  [encoding & body]
+  `(binding [*default-encoding* ~encoding]
+     ~@body))
+
+(defn encode [s]
+  "urlencode"
+  (URLEncoder/encode (as-str s) *default-encoding*))
+
 (defn encode-params
   "Turn a map of parameters into a urlencoded string."
   [params]
-  (letfn [(encode [s] (URLEncoder/encode (as-str s)))]
-    (str/join "&"
-      (for [[k v] params]
-        (str (encode k) "=" (encode v))))))
+  (str/join "&"
+    (for [[k v] params]
+      (str (encode k) "=" (encode v)))))
 
 (defn url
   "Creates a URL string from a variable list of arguments and an optional

--- a/test/hiccup/test/page_helpers.clj
+++ b/test/hiccup/test/page_helpers.clj
@@ -7,7 +7,15 @@
     {"a" "b"}       "a=b"
     {:a "b"}        "a=b"
     {:a "b" :c "d"} "a=b&c=d"
-    {:a "&"}        "a=%26"))
+    {:a "&"}        "a=%26"
+    {:é "è"}        "%C3%A9=%C3%A8"))
+
+(deftest encode-params-with-encoding-test
+  (are [e s] (= (with-encoding e (encode-params {:iroha "いろは"})) s)
+    "UTF-8"       "iroha=%E3%81%84%E3%82%8D%E3%81%AF"
+    "Shift_JIS"   "iroha=%82%A2%82%EB%82%CD"
+    "EUC-JP"      "iroha=%A4%A4%A4%ED%A4%CF"
+    "ISO-2022-JP" "iroha=%1B%24%42%24%24%24%6D%24%4F%1B%28%42"))
 
 (deftest url-test
   (are [u s] (= u s)


### PR DESCRIPTION
Added _default-encoding_ and with-encoding macro to explicitly set character encoding
