### PR TITLE
Added an explicit end tag to the 'table' element

### DIFF
--- a/src/hiccup/core.clj
+++ b/src/hiccup/core.clj
@@ -62,7 +62,7 @@
   container-tags
   #{"a" "b" "body" "dd" "div" "dl" "dt" "em" "fieldset" "form" "h1" "h2" "h3"
     "h4" "h5" "h6" "head" "html" "i" "iframe" "label" "li" "ol" "option" "pre" 
-    "script" "span" "strong" "style" "textarea" "ul"})
+    "script" "span" "strong" "style" "table" "textarea" "ul"})
 
 (defn- normalize-element
   "Ensure a tag vector is of the form [tag-name attrs content]."


### PR DESCRIPTION
'table' tags can be incorrectly rendered if they don't have an explicit ending tag. For example, in Chrome the following html renders the table below the unordered list:

``` <html>
  <head></head>
  <body>
    <h1></h1>
    <table />
    <ul><li>1</li><li>2</li></ul>
  </body>
</html>
```

replacing `<table/>` with `<table></table>` fixes this
