### PR TITLE
Add email input field

### DIFF
--- a/src/hiccup/form_helpers.clj
+++ b/src/hiccup/form_helpers.clj
@@ -46,6 +46,11 @@
   ([name] (password-field name nil))
   ([name value] (input-field "password" name value)))
 
+(defelem email-field
+  "Creates a new email input field."
+  ([name] (email-field name nil))
+  ([name value] (input-field "email" name value)))
+
 (defelem check-box
   "Creates a check box."
   ([name] (check-box name nil))

--- a/test/hiccup/test/form_helpers.clj
+++ b/test/hiccup/test/form_helpers.clj
@@ -37,6 +37,14 @@
   (is (= (html (password-field {:class "classy"} :foo "bar"))
          "<input class=\"classy\" id=\"foo\" name=\"foo\" type=\"password\" value=\"bar\" />")))
 
+(deftest test-email-field
+  (is (= (html (email-field :foo "bar"))
+         "<input id=\"foo\" name=\"foo\" type=\"email\" value=\"bar\" />")))
+
+(deftest test-email-field-with-extra-atts
+  (is (= (html (email-field {:class "classy"} :foo "bar"))
+         "<input class=\"classy\" id=\"foo\" name=\"foo\" type=\"email\" value=\"bar\" />")))
+
 (deftest test-radio-button
   (is (= (html (radio-button :foo true 1))
          (str "<input checked=\"checked\" id=\"foo-1\" name=\"foo\""


### PR DESCRIPTION
Add a function to generate an input of type "email" to the form-helpers, so mobile browsers can show a different keyboard.
