### PR TITLE
Fixed basic test assertions (closing parens were in the wrong place)

### DIFF
--- a/test/hiccup/test/core.clj
+++ b/test/hiccup/test/core.clj
@@ -12,9 +12,9 @@
 
 (deftest tag-names
   (testing "basic tags"
-    (is (= (html [:div] "<div></div>")))
-    (is (= (html ["div"] "<div></div>")))
-    (is (= (html ['div] "<div></div>"))))
+    (is (= (html [:div]) "<div></div>"))
+    (is (= (html ["div"]) "<div></div>"))
+    (is (= (html ['div]) "<div></div>")))
   (testing "tag syntax sugar"
     (is (= (html [:div#foo]) "<div id=\"foo\"></div>"))
     (is (= (html [:div.foo]) "<div class=\"foo\"></div>"))


### PR DESCRIPTION
In basic core tests, nothing was really asserted because expected value was included in the html expr:

```
(is (= (html [:div] "<div></div>")))
```
