### PR TITLE
use img instead of image

### DIFF
--- a/src/hiccup/page_helpers.clj
+++ b/src/hiccup/page_helpers.clj
@@ -111,8 +111,8 @@
 
 (defelem image
   "Create an image tag"
-  ([src]     [:image {:src (resolve-uri src)}])
-  ([src alt] [:image {:src (resolve-uri src), :alt alt}]))
+  ([src]     [:img {:src (resolve-uri src)}])
+  ([src alt] [:img {:src (resolve-uri src), :alt alt}]))
 
 (defn encode-params
   "Turn a map of parameters into a urlencoded string."


### PR DESCRIPTION
HTML4, HTML5, and XHTML all specify the tag as &lt;img&gt;, not &lt;image&gt;. Changed the image helper to generate the spec-compliant markup.
