### PR TITLE
Remove the one small dependency on clojure.contrib to make Hiccup more Clojure 1.3 friendly

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,4 @@
 (defproject hiccup "0.3.6"
   :description "A fast library for rendering HTML in Clojure"
   :url "http://github.com/weavejester/hiccup"
-  :dependencies [[org.clojure/clojure "1.2.0"]]
-  :dev-dependencies [[org.clojure/clojure-contrib "1.2.0"]])
+  :dependencies [[org.clojure/clojure "1.2.0"]])

--- a/test/hiccup/test/core.clj
+++ b/test/hiccup/test/core.clj
@@ -1,6 +1,5 @@
 (ns hiccup.test.core
   (:use clojure.test
-        clojure.contrib.mock.test-adapter
         hiccup.core))
 
 (deftest escaped-chars
@@ -99,9 +98,10 @@
                          [:span "bar"])])
            "<div><span>foo</span></div>")))
   (testing "values are evaluated only once"
-    (declare foo)
-    (expect [foo (times 1 (returns "foo"))]
-      (html [:div (foo)]))))
+    (let [called (atom 0)
+          foo (fn [] (swap! called inc))]
+      (html [:div (foo)])
+      (is (= 1 @called)))))
 
 (deftest render-modes
   (testing "closed tag"


### PR DESCRIPTION
Remove dependency on clojure.contrib to make hiccup more Clojure 1.3 friendly
