### PR TITLE
Pull request for with-group to take and return a group

### DIFF
--- a/src/hiccup/form_helpers.clj
+++ b/src/hiccup/form_helpers.clj
@@ -9,7 +9,7 @@
   nested-params middleware."
   [group & body]
   `(binding [*group* (conj *group* (as-str ~group))]
-     ~@body))
+     (list ~@body)))
 
 (defn- make-name
   "Create a field name from the supplied argument the current field group."

--- a/test/hiccup/test/form_helpers.clj
+++ b/test/hiccup/test/form_helpers.clj
@@ -140,32 +140,35 @@
 
 (deftest test-with-group
   (testing "hidden-field"
-    (is (= (with-group :foo (html (hidden-field :bar "val")))
+    (is (= (html (with-group :foo (hidden-field :bar "val")))
            "<input id=\"foo-bar\" name=\"foo[bar]\" type=\"hidden\" value=\"val\" />")))
   (testing "text-field"
-    (is (= (with-group :foo (html (text-field :bar)))
+    (is (= (html (with-group :foo (text-field :bar)))
            "<input id=\"foo-bar\" name=\"foo[bar]\" type=\"text\" />")))
   (testing "checkbox"
-    (is (= (with-group :foo (html (check-box :bar)))
+    (is (= (html (with-group :foo (check-box :bar)))
            "<input id=\"foo-bar\" name=\"foo[bar]\" type=\"checkbox\" value=\"true\" />")))
   (testing "password-field"
-    (is (= (with-group :foo (html (password-field :bar)))
+    (is (= (html (with-group :foo (password-field :bar)))
            "<input id=\"foo-bar\" name=\"foo[bar]\" type=\"password\" />")))
   (testing "radio-button"
-    (is (= (with-group :foo (html (radio-button :bar false "val")))
+    (is (= (html (with-group :foo (radio-button :bar false "val")))
            "<input id=\"foo-bar-val\" name=\"foo[bar]\" type=\"radio\" value=\"val\" />")))
   (testing "drop-down"
-    (is (= (with-group :foo (html (drop-down :bar [])))
+    (is (= (html (with-group :foo (drop-down :bar [])))
            (str "<select id=\"foo-bar\" name=\"foo[bar]\"></select>"))))
   (testing "text-area"
-    (is (= (with-group :foo (html (text-area :bar)))
+    (is (= (html (with-group :foo (text-area :bar)))
            (str "<textarea id=\"foo-bar\" name=\"foo[bar]\"></textarea>"))))
   (testing "file-upload"
-    (is (= (with-group :foo (html (file-upload :bar)))
+    (is (= (html (with-group :foo (file-upload :bar)))
            "<input id=\"foo-bar\" name=\"foo[bar]\" type=\"file\" />")))
   (testing "label"
-    (is (= (with-group :foo (html (label :bar "Bar")))
+    (is (= (html (with-group :foo (label :bar "Bar")))
            "<label for=\"foo-bar\">Bar</label>")))
   (testing "multiple with-groups"
-    (is (= (with-group :foo (with-group :bar (html (text-field :baz))))
-           "<input id=\"foo-bar-baz\" name=\"foo[bar][baz]\" type=\"text\" />"))))
+    (is (= (html (with-group :foo (with-group :bar (text-field :baz))))
+           "<input id=\"foo-bar-baz\" name=\"foo[bar][baz]\" type=\"text\" />")))
+  (testing "multiple elements"
+    (is (= (html (with-group :foo (label :bar "Bar") (text-field :var)))
+           "<label for=\"foo-bar\">Bar</label><input id=\"foo-var\" name=\"foo[var]\" type=\"text\" />"))))


### PR DESCRIPTION
"with-group" should accept and return a group of forms passed in, but actually only returns the last as a single element. This changes the behaviour to match that found on http://weavejester.com/grouping-fields-in-hiccup and should work fine when passed into "html" or "form-to". I've updated the tests and added a new one.
