### PR TITLE
Removed dynamic var warning for Clojure 1.3.

### DIFF
--- a/src/hiccup/page_helpers.clj
+++ b/src/hiccup/page_helpers.clj
@@ -117,7 +117,8 @@
 (def
  #^{:doc "Name of the default encoding to use .
   Default is UTF-8."
-    :tag "java.lang.String"}
+    :tag "java.lang.String"
+    :dynamic true}
  *default-encoding* "UTF-8")
 
 (defmacro with-encoding


### PR DESCRIPTION
see title...
