### PR TITLE
Ratios should render as floating point numbers

### DIFF
--- a/src/hiccup/util.clj
+++ b/src/hiccup/util.clj
@@ -19,6 +19,8 @@
 (extend-protocol ToString
   clojure.lang.Keyword
   (to-str [k] (name k))
+  clojure.lang.Ratio
+  (to-str [r] (str (float r)))
   java.net.URI
   (to-str [u]
     (if (or (.isAbsolute u)

--- a/test/hiccup/test/util.clj
+++ b/test/hiccup/test/util.clj
@@ -14,6 +14,7 @@
   (is (= (as-str "foo") "foo"))
   (is (= (as-str :foo) "foo"))
   (is (= (as-str 100) "100"))
+  (is (= (as-str 4/3) (str (float 4/3))))
   (is (= (as-str "a" :b 3) "ab3"))
   (is (= (as-str (URI. "/foo")) "/foo")))
 


### PR DESCRIPTION
HTML hates fractions.

This closes #40.
