### PR TITLE
Generate correct markup for selected options.

### DIFF
--- a/src/hiccup/form.clj
+++ b/src/hiccup/form.clj
@@ -79,10 +79,12 @@
   ([coll] (select-options coll nil))
   ([coll selected]
     (for [x coll]
-      (if (sequential? x)
-        (let [[text val] x]
-          [:option {:value val :selected (= val selected)} text])
-        [:option {:selected (= x selected)} x]))))
+      (let [[text val] (if (sequential? x) x [x x])
+            attr {:value val}
+            attr (if (= val selected)
+                   (assoc attr :selected "selected")
+                   attr)]
+        [:option attr text]))))
 
 (defelem drop-down
   "Creates a drop-down box using the <select> tag."

--- a/test/hiccup/test/form.clj
+++ b/test/hiccup/test/form.clj
@@ -58,11 +58,13 @@
 (deftest test-select-options
   (are [x y] (= (html x) y)
     (select-options ["foo" "bar" "baz"])
-      "<option>foo</option><option>bar</option><option>baz</option>"
+      "<option value=\"foo\">foo</option><option value=\"bar\">bar</option><option value=\"baz\">baz</option>"
     (select-options ["foo" "bar"] "bar")
-      "<option>foo</option><option selected=\"selected\">bar</option>"
+      "<option value=\"foo\">foo</option><option selected=\"selected\" value=\"bar\">bar</option>"
     (select-options [["Foo" 1] ["Bar" 2]])
-      "<option value=\"1\">Foo</option><option value=\"2\">Bar</option>"))
+      "<option value=\"1\">Foo</option><option value=\"2\">Bar</option>")
+    (select-options [["Foo" 1] ["Bar" 2] 2])
+      "<option value=\"1\">Foo</option><option value=\"2\" selected=\"selected\">Bar</option>" )
 
 (deftest test-drop-down
   (let [options ["op1" "op2"]


### PR DESCRIPTION
Previously, each <option> had a "selected=..." attribute, with its value set to true or false depending on whether it was supposed to be selected.  Browsers interpret this to mean that we want them all to be selected.  The correct behavior is to leave out the "selected" attribute for all but the element that is to be selected.

Note that I also amended the tests to make sure that this works properly.
