### PR TITLE
Explicit ending tags for <section>, <aside>, and others

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -36,9 +36,10 @@
 (def ^{:doc "A list of elements that need an explicit ending tag when rendered."
        :private true}
   container-tags
-  #{"a" "b" "body" "canvas" "dd" "div" "dl" "dt" "em" "fieldset" "form" "h1" "h2" "h3"
-    "h4" "h5" "h6" "head" "html" "i" "iframe" "label" "li" "ol" "option" "pre" 
-    "script" "span" "strong" "style" "table" "textarea" "title" "ul"})
+  #{"a" "article" "aside" "b" "body" "canvas" "dd" "div" "dl" "dt" "em" "fieldset"
+    "footer" "form" "h1" "h2" "h3" "h4" "h5" "h6" "head" "header" "hgroup" "html"
+    "i" "iframe" "label" "li" "nav" "ol" "option" "pre" "section" "script" "span"
+    "strong" "style" "table" "textarea" "title" "ul"})
 
 (defn normalize-element
   "Ensure an element vector is of the form [tag-name attrs content]."

--- a/test/hiccup/test/core.clj
+++ b/test/hiccup/test/core.clj
@@ -25,7 +25,8 @@
     (is (= (html [:text]) "<text />"))
     (is (= (html [:a]) "<a></a>"))
     (is (= (html [:iframe]) "<iframe></iframe>"))
-    (is (= (html [:title]) "<title></title>")))
+    (is (= (html [:title]) "<title></title>"))
+    (is (= (html [:section]) "<section></section>")))
   (testing "tags containing text"
     (is (= (html [:text "Lorem Ipsum"]) "<text>Lorem Ipsum</text>")))
   (testing "contents are concatenated"


### PR DESCRIPTION
Added explicit end tags for aside, header, nav, article, section, footer, and hgroup.
