### PR TITLE
concatenate attributes in the tag and map

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -51,7 +51,9 @@
                           :class (if class (.replace ^String class "." " "))}
         map-attrs        (first content)]
     (if (map? map-attrs)
-      [tag (merge tag-attrs map-attrs) (next content)]
+      [tag
+       (merge-with #(if %1 (str %1 " " %2) %2) tag-attrs map-attrs)
+       (next content)]
       [tag tag-attrs content])))
 
 (defmulti render-html

--- a/test/hiccup/test/core.clj
+++ b/test/hiccup/test/core.clj
@@ -62,7 +62,10 @@
            "<input type=\"checkbox\" />")))
   (testing "nil attributes"
     (is (= (html [:span {:class nil} "foo"])
-           "<span>foo</span>"))))
+           "<span>foo</span>")))
+  (testing "concatenate attributes in the map and tag"
+    (is (= (html [:div.foo {:class bar} "baz"])
+           "<div class=\"foo bar\">baz</div>"))))
 
 (deftest compiled-tags
   (testing "tag content can be vars"


### PR DESCRIPTION
This pull request allows classes to be specified in both the attribute tag and the map. e.g.

```
[:div.foo {:class "bar"} "baz"]
```

evaluates to:

```
<div class="foo bar">baz</div>
```
