### PR TITLE
Refactored include- functions to add less-css support

### DIFF
--- a/src/hiccup/page.clj
+++ b/src/hiccup/page.clj
@@ -68,14 +68,32 @@
            (doctype :html5)
            [:html {:lang (options# :lang)} ~@contents])))))
 
-(defn include-js
-  "Include a list of external javascript files."
-  [& scripts]
+(defn include-script
+  "Include a list of external script files"
+  [type & scripts]
   (for [script scripts]
-    [:script {:type "text/javascript", :src (to-uri script)}]))
+    [:script {:type type, :src (to-uri script)}]))
 
-(defn include-css
-  "Include a list of external stylesheet files."
-  [& styles]
-  (for [style styles]
-    [:link {:type "text/css", :href (to-uri style), :rel "stylesheet"}]))
+(def
+  #^{:doc "Include a list of external javascript files"
+     :arglists '([& scripts])}
+  include-js
+  (partial include-script "text/javascript"))
+
+(defn include-link
+  "Include a list of externally linked files"
+  [type rel & hrefs]
+  (for [href hrefs]
+    [:link {:type type, :href (to-uri href), :rel rel}]))
+
+(def
+  #^{:doc "Include a list of external css stylesheet files"
+     :arglists '([& styles])}
+  include-css
+  (partial include-link "text/css" "stylesheet"))
+
+(def
+  #^{:doc "Include a list of external less (http://lesscss.org/) stylesheet files"
+     :arglists '([& styles])}
+  include-less
+  (partial include-link "text/css" "stylesheet/less"))

--- a/test/hiccup/test/page.clj
+++ b/test/hiccup/test/page.clj
@@ -46,12 +46,26 @@
                 "<html lang=\"en\" xml:lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\">"
                 "<body>Hello World</body></html>")))))
 
+(deftest include-script-test
+  (is (= (include-script "text/script" "foo.script")
+         (list [:script {:type "text/script", :src (URI. "foo.script")}])))
+  (is (= (include-script "text/script" "foo.script" "bar.script")
+         (list [:script {:type "text/script", :src (URI. "foo.script")}]
+               [:script {:type "text/script", :src (URI. "bar.script")}]))))
+
 (deftest include-js-test
   (is (= (include-js "foo.js")
          (list [:script {:type "text/javascript", :src (URI. "foo.js")}])))
   (is (= (include-js "foo.js" "bar.js")
          (list [:script {:type "text/javascript", :src (URI. "foo.js")}]
                [:script {:type "text/javascript", :src (URI. "bar.js")}]))))
+
+(deftest include-link-test
+  (is (= (include-link "text/plain" "contents" "foo.txt")
+         (list [:link {:type "text/plain", :href (URI. "foo.txt"), :rel "contents"}])))
+  (is (= (include-link "text/plain" "contents" "foo.txt" "bar.txt")
+         (list [:link {:type "text/plain", :href (URI. "foo.txt"), :rel "contents"}]
+               [:link {:type "text/plain", :href (URI. "bar.txt"), :rel "contents"}]))))
 
 (deftest include-css-test
   (is (= (include-css "foo.css")


### PR DESCRIPTION
I needed to use Less css stylesheets in a project but couldn't see an easy way to do it without reverting to using raw html functions rather than the slicker include-css function, so I reworked the include-js and include-css functions to more general include-script and include-link, then switched the original functions to use partials based on those.
