### PR TITLE
Merge attributes by concatenating :class and overriding :id

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -40,6 +40,11 @@
     "footer" "form" "h1" "h2" "h3" "h4" "h5" "h6" "head" "header" "hgroup" "html"
     "i" "iframe" "label" "li" "nav" "ol" "option" "pre" "section" "script" "span"
     "strong" "style" "table" "textarea" "title" "ul"})
+ 
+(defn- merge-attributes [{:keys [id class]} map-attrs]
+  (->> map-attrs
+       (merge (if id {:id id}))
+       (merge-with #(if %1 (str %1 " " %2) %2) (if class {:class class}))))
 
 (defn normalize-element
   "Ensure an element vector is of the form [tag-name attrs content]."
@@ -51,7 +56,7 @@
                           :class (if class (.replace ^String class "." " "))}
         map-attrs        (first content)]
     (if (map? map-attrs)
-      [tag (merge tag-attrs map-attrs) (next content)]
+      [tag (merge-attributes tag-attrs map-attrs) (next content)]
       [tag tag-attrs content])))
 
 (defmulti render-html

--- a/test/hiccup/test/core.clj
+++ b/test/hiccup/test/core.clj
@@ -62,7 +62,12 @@
            "<input type=\"checkbox\" />")))
   (testing "nil attributes"
     (is (= (html [:span {:class nil} "foo"])
-           "<span>foo</span>"))))
+           "<span>foo</span>")))
+  (testing "resolving conflicts between attributes in the map and tag"
+    (is (= (html [:div.foo {:class "bar"} "baz"])
+           "<div class=\"foo bar\">baz</div>"))
+    (is (= (html [:div#bar.foo {:id "baq"} "baz"])
+           "<div class=\"foo\" id=\"baq\">baz</div>"))))
 
 (deftest compiled-tags
   (testing "tag content can be vars"


### PR DESCRIPTION
Hi,
    This pull request deals with conflicts in class and id attributes. Class attributes are concatenated and ID attributes are replaced:

```
[:div.foo {:class "bar"} "baz"] =>  <div class="foo bar">baz</div>
[:div#foo {:id "bar"} "baz"]    =>  <div id="bar">baz</div>
```

(This supersedes [pull request 57](https://github.com/weavejester/hiccup/pull/57) which I've now closed)
