### PR TITLE
Input tags rendered as input elements

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -41,6 +41,13 @@
     "i" "iframe" "label" "li" "nav" "ol" "option" "pre" "section" "script" "span"
     "strong" "style" "table" "textarea" "title" "ul"})
 
+(def ^{:doc "Tags that should be converted to input elements."
+       :private true}
+  input-tags
+  #{"button" "checkbox" "color" "date" "datetime" "datetime-local" "email" "file"
+    "hidden" "image" "month" "number" "password" "radio" "range" "reset" "search"
+    "submit" "tel" "text" "time" "url" "week"})
+
 (defn normalize-element
   "Ensure an element vector is of the form [tag-name attrs content]."
   [[tag & content]]
@@ -63,11 +70,13 @@
   "Render an element vector as a HTML element."
   [element]
   (let [[tag attrs content] (normalize-element element)]
-    (if (or content (container-tags tag))
-      (str "<" tag (render-attr-map attrs) ">"
-           (render-html content)
-           "</" tag ">")
-      (str "<" tag (render-attr-map attrs) (end-tag)))))
+    (if (and (input-tags tag) (nil? content))
+      (recur ["input" (assoc attrs :type tag)])
+      (if (or content (container-tags tag))
+        (str "<" tag (render-attr-map attrs) ">"
+             (render-html content)
+             "</" tag ">")
+        (str "<" tag (render-attr-map attrs) (end-tag))))))
 
 (defmethod render-html IPersistentVector
   [element]

--- a/test/hiccup/test/core.clj
+++ b/test/hiccup/test/core.clj
@@ -22,7 +22,7 @@
     (is (= (html [:div]) "<div></div>"))
     (is (= (html [:h1]) "<h1></h1>"))
     (is (= (html [:script]) "<script></script>"))
-    (is (= (html [:text]) "<text />"))
+    (is (= (html [:br]) "<br />"))
     (is (= (html [:a]) "<a></a>"))
     (is (= (html [:iframe]) "<iframe></iframe>"))
     (is (= (html [:title]) "<title></title>"))
@@ -62,7 +62,14 @@
            "<input type=\"checkbox\" />")))
   (testing "nil attributes"
     (is (= (html [:span {:class nil} "foo"])
-           "<span>foo</span>"))))
+           "<span>foo</span>")))
+  (testing "input tags rendered as input elements"
+    (is (= (html [:password#foo.bar {:name "baz"}])
+           "<input class=\"bar\" id=\"foo\" name=\"baz\" type=\"password\" />"))
+    (is (= (html [:button {:name "foo" :value "bar"}])
+           "<input name=\"foo\" type=\"button\" value=\"bar\" />"))
+    (is (= (html [:button {:name "foo" :type "button"} [:div "bar"]])
+           "<button name=\"foo\" type=\"button\"><div>bar</div></button>"))))
 
 (deftest compiled-tags
   (testing "tag content can be vars"


### PR DESCRIPTION
This patch allows input elements to be treated like any other tag in Hiccup, with the proviso that they have no content. For example an input of type "password" can be created with the familiar Hiccup form `[:password#someid.someclass.otherclass {:value "foo"}]`.

If there is content the tag gets rendered like any other element. If it wasn't for the HTML "button"  element (`<button type="button">Hi, I'm a button</button>`), which is also the name for an HTML input type (`<input type="button" value="Hi, I'm a button too!" />`) there would be some cheap opportunities for error handling, but there you go.

This patch does not displace the functions in the hiccup.form namespace (which are unaffected by this change), but may be a step towards deprecating the majority of the functions that create HTML input elements.

Apart from the few lines to implement the change and its tests, there was one change to replace the non-element `<text />` with `<br />` in the "empty tags" tests. 

Those people keen to use all those fancy HTML5 input types will rejoice I'm sure! ;)
