### PR TITLE
Support for optgroups

### DIFF
--- a/src/hiccup/form.clj
+++ b/src/hiccup/form.clj
@@ -81,7 +81,9 @@
     (for [x coll]
       (if (sequential? x)
         (let [[text val] x]
-          [:option {:value val :selected (= val selected)} text])
+          (if (sequential? val)
+            [:optgroup {:label text} (select-options val selected)]
+            [:option {:value val :selected (= val selected)} text]))
         [:option {:selected (= x selected)} x]))))
 
 (defelem drop-down

--- a/test/hiccup/test/form.clj
+++ b/test/hiccup/test/form.clj
@@ -62,7 +62,18 @@
     (select-options ["foo" "bar"] "bar")
       "<option>foo</option><option selected=\"selected\">bar</option>"
     (select-options [["Foo" 1] ["Bar" 2]])
-      "<option value=\"1\">Foo</option><option value=\"2\">Bar</option>"))
+      "<option value=\"1\">Foo</option><option value=\"2\">Bar</option>"
+    (select-options [["Foo" [1 2]] ["Bar" [3 4]]])
+      (str "<optgroup label=\"Foo\"><option>1</option><option>2</option></optgroup>"
+           "<optgroup label=\"Bar\"><option>3</option><option>4</option></optgroup>")
+    (select-options [["Foo" [["bar" 1] ["baz" 2]]]])
+      (str "<optgroup label=\"Foo\"><option value=\"1\">bar</option>"
+           "<option value=\"2\">baz</option></optgroup>")
+    (select-options [["Foo" [1 2]]] 2)
+      (str "<optgroup label=\"Foo\"><option>1</option>"
+           "<option selected=\"selected\">2</option></optgroup>")))
+
+
 
 (deftest test-drop-down
   (let [options ["op1" "op2"]


### PR DESCRIPTION
I added support for optgroups in dropdown menus. The syntax is:

``` clojure
(select-options [["Optgroup label"
                  ["Nested option #1"
                   "Nested option #2"
                   ["Nested option #3" "nested-value-3"]]]])
```

This should not break backwards compatibility, as the whole test suite passes. On that note, I also added tests to cover this new functionality.
