### PR TITLE
Allow setting arbitrary properties on the html5 root element

### DIFF
--- a/src/hiccup/page.clj
+++ b/src/hiccup/page.clj
@@ -1,7 +1,8 @@
 (ns hiccup.page
   "Functions for setting up HTML pages."
   (:use hiccup.core 
-        hiccup.util))
+        hiccup.util
+        hiccup.def))
 
 (def doctype
   {:html4
@@ -16,7 +17,7 @@
    :html5
    "<!DOCTYPE html>\n"})
 
-(defn xhtml-tag
+(defelem xhtml-tag
   "Create an XHTML element for the specified language."
   [lang & contents]
   [:html {:xmlns "http://www.w3.org/1999/xhtml"
@@ -58,15 +59,15 @@
   (if-not (map? options)
     `(html5 {} ~options ~@contents)
     (if (options :xml?)
-      `(let [options# ~options]
+      `(let [options# (dissoc ~options :xml?)]
          (html {:mode :xml}
            (xml-declaration (options# :encoding "UTF-8"))
            (doctype :html5)
-           (xhtml-tag (options# :lang) ~@contents)))
-      `(let [options# ~options]
+           (xhtml-tag options# (options# :lang) ~@contents)))
+      `(let [options# (dissoc ~options :xml?)]
          (html {:mode :html}
            (doctype :html5)
-           [:html {:lang (options# :lang)} ~@contents])))))
+           [:html options# ~@contents])))))
 
 (defn include-js
   "Include a list of external javascript files."

--- a/test/hiccup/test/page.clj
+++ b/test/hiccup/test/page.clj
@@ -34,7 +34,18 @@
     (is (= (html5 [:body [:p "Hello" [:br] "World"]])
            "<!DOCTYPE html>\n<html><body><p>Hello<br>World</p></body></html>"))
     (is (= (html5 {:lang "en"} [:body "Hello World"])
-           "<!DOCTYPE html>\n<html lang=\"en\"><body>Hello World</body></html>")))
+           "<!DOCTYPE html>\n<html lang=\"en\"><body>Hello World</body></html>"))
+    (is (= (html5 {:prefix "og: http://ogp.me/ns#"}
+                  [:body "Hello World"])
+           (str "<!DOCTYPE html>\n"
+                "<html prefix=\"og: http://ogp.me/ns#\">"
+                "<body>Hello World</body></html>")))
+    (is (= (html5 {:prefix "og: http://ogp.me/ns#"
+                   :lang "en"}
+                  [:body "Hello World"])
+           (str "<!DOCTYPE html>\n"
+                "<html lang=\"en\" prefix=\"og: http://ogp.me/ns#\">"
+                "<body>Hello World</body></html>"))))
   (testing "XML mode"
     (is (= (html5 {:xml? true} [:body [:p "Hello" [:br] "World"]])
            (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
@@ -44,6 +55,18 @@
            (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                 "<!DOCTYPE html>\n"
                 "<html lang=\"en\" xml:lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\">"
+                "<body>Hello World</body></html>")))
+    (is (= (html5 {:xml? true,
+                   "xml:og" "http://ogp.me/ns#"} [:body "Hello World"])
+           (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                "<!DOCTYPE html>\n"
+                "<html xml:og=\"http://ogp.me/ns#\" xmlns=\"http://www.w3.org/1999/xhtml\">"
+                "<body>Hello World</body></html>")))    
+    (is (= (html5 {:xml? true, :lang "en"
+                   "xml:og" "http://ogp.me/ns#"} [:body "Hello World"])
+           (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                "<!DOCTYPE html>\n"
+                "<html lang=\"en\" xml:lang=\"en\" xml:og=\"http://ogp.me/ns#\" xmlns=\"http://www.w3.org/1999/xhtml\">"
                 "<body>Hello World</body></html>")))))
 
 (deftest include-js-test


### PR DESCRIPTION
Allow setting arbitrary properties on the html5 root element

**Update**: Reworked the patch so that it doesn't use `:root-options` anymore, but dissocs :xml? instead.
**Update#2**: Another rework, uses `defelem` for `xhtml-tags`
