### PR TITLE
use fully qualified class in type-hint, works around a clojure bug

### DIFF
--- a/src/hiccup/util.clj
+++ b/src/hiccup/util.clj
@@ -42,7 +42,7 @@
   (apply str (map to-str xs)))
 
 (defprotocol ToURI
-  (^URI to-uri [x] "Convert a value into a URI."))
+  (^java.net.URI to-uri [x] "Convert a value into a URI."))
 
 (extend-protocol ToURI
   java.net.URI


### PR DESCRIPTION
Due to a clojure bug, this will result in the symbol 'URI to be used as a type-hint, potentially causing exceptions when to-uri is used in a namespace that doesn't import URI.

A workaround is tagging with the fully qualified class name.

Found using the Eastwood lint tool.
