### PR TITLE
Implemented midje-readme, and fixed readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 *.class
 .lein-*
 .nrepl-port
+test/readme.clj

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ Documentation
 
 * [Wiki](https://github.com/weavejester/hiccup/wiki)
 * [API Docs](http://weavejester.github.com/hiccup)
-    
+
 Syntax
 ------
 
 Here is a basic example of Hiccup syntax:
 
 ```clojure
-user=> (use 'hiccup.core)
-nil
-user=> (html [:span {:class "foo"} "bar"])
+(use 'hiccup.core)
+(html [:span {:class "foo"} "bar"])
+=>
 "<span class=\"foo\">bar</span>"
 ```
 
@@ -40,18 +40,15 @@ Hiccup is intelligent enough to render different HTML elements in
 different ways, in order to accommodate browser quirks:
 
 ```clojure
-user=> (html [:script])
-"<script></script>"
-user=> (html [:p])
-"<p />"
+(html [:script]) => "<script></script>"
+(html [:br]) => "<br />"
 ```
 
 And provides a CSS-like shortcut for denoting `id` and `class`
 attributes:
 
 ```clojure
-user=> (html [:div#foo.bar.baz "bang"])
-"<div id=\"foo\" class=\"bar baz\">bang</div>"
+(html [:div#foo.bar.baz "bang"]) => "<div class=\"bar baz\" id=\"foo\">bang</div>"
 ```
 
 If the body of the element is a seq, its contents will be expanded out
@@ -59,8 +56,9 @@ into the element body. This makes working with forms like `map` and
 `for` more convenient:
 
 ```clojure
-user=> (html [:ul
-               (for [x (range 1 4)]
-                 [:li x])])
+(html [:ul
+        (for [x (range 1 4)]
+          [:li x])])
+=>
 "<ul><li>1</li><li>2</li><li>3</li></ul>"
 ```

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,14 @@
           :sources ["src"]
           :src-dir-uri "http://github.com/weavejester/hiccup/blob/1.0.5/"
           :src-linenum-anchor-prefix "L"}
+
   :profiles
   {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
    :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
-   :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}})
+   :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
+   :dev {:plugins [[midje-readme "1.0.2"]
+                   [lein-midje "3.0.0"]]
+         :dependencies [[midje "1.5.0"]
+                        [org.clojure/clojure "1.5.1"]]}
+
+   })


### PR DESCRIPTION
This PR implements automatic testing of the readme with midje via midje-readme. It also fixes the error in the documentation where it claimed `[:p]` would render as `<p />` which hiccup doesn't do. I changed it to `[:br]` which does do what the text describes.
