### PR TITLE
Escape all strings by default

### DIFF
--- a/src/hiccup/core.clj
+++ b/src/hiccup/core.clj
@@ -10,8 +10,6 @@
   (if-let [mode (and (map? options) (:mode options))]
     (binding [*html-mode* mode]
       `(binding [*html-mode* ~mode]
-         ~(apply compile-html content)))
-    (apply compile-html options content)))
+         (raw-string ~(apply compile-html content))))
+    `(raw-string ~(apply compile-html options content))))
 
-(def ^{:doc "Alias for hiccup.util/escape-html"}
-  h escape-html)

--- a/src/hiccup/form.clj
+++ b/src/hiccup/form.clj
@@ -98,7 +98,7 @@
   ([name] (text-area name nil))
   ([name value]
     [:textarea {:name (make-name name), :id (make-id name)}
-      (escape-html value)]))
+      value]))
 
 (defelem file-upload
   "Creates a file upload input."

--- a/src/hiccup/page.clj
+++ b/src/hiccup/page.clj
@@ -6,16 +6,16 @@
 
 (def doctype
   {:html4
-   (str "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" "
-        "\"http://www.w3.org/TR/html4/strict.dtd\">\n")
+   (raw-string "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" "
+               "\"http://www.w3.org/TR/html4/strict.dtd\">\n")
    :xhtml-strict
-   (str "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "
-        "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n")
+   (raw-string "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "
+               "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n")
    :xhtml-transitional
-   (str "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" "
-        "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n")
+   (raw-string "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" "
+               "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n")
    :html5
-   "<!DOCTYPE html>\n"})
+   (raw-string "<!DOCTYPE html>\n")})
 
 (defelem xhtml-tag
   "Create an XHTML element for the specified language."
@@ -28,7 +28,7 @@
 (defn xml-declaration
   "Create a standard XML declaration for the following encoding."
   [encoding]
-  (str "<?xml version=\"1.0\" encoding=\"" encoding "\"?>\n"))
+  (raw-string "<?xml version=\"1.0\" encoding=\"" encoding "\"?>\n"))
 
 (defmacro html4
   "Create a HTML 4 document with the supplied contents. The first argument

--- a/src/hiccup/util.clj
+++ b/src/hiccup/util.clj
@@ -52,6 +52,24 @@
   String
   (to-uri [s] (URI. s)))
 
+(deftype RawString [^String s]
+  Object
+  (^String toString [this] s)
+  (^boolean equals [this other]
+    (and (instance? RawString other)
+         (= s  (.toString other)))))
+
+(defn raw-string
+  "Wraps a string to an object that will be pasted to HTML without escaping."
+  ([] (RawString. ""))
+  ([x] (RawString. x))
+  ([x & xs] (RawString. (apply str x xs))))
+
+(defn raw-string?
+  "Returns true if x is a RawString"
+  [x]
+  (instance? RawString x))
+
 (defn escape-html
   "Change special characters into HTML character entities."
   [text]

--- a/test/hiccup/test/core.clj
+++ b/test/hiccup/test/core.clj
@@ -1,110 +1,117 @@
 (ns hiccup.test.core
   (:use clojure.test
-        hiccup.core))
+        hiccup.core
+        hiccup.util))
+
+(deftest return-types
+  (testing "html returns a RawString"
+    (is (raw-string? (html [:div]))))
+  (testing "converting to string"
+    (= (str (html [:div])) "<div></div>")))
 
 (deftest tag-names
   (testing "basic tags"
-    (is (= (html [:div]) "<div></div>"))
-    (is (= (html ["div"]) "<div></div>"))
-    (is (= (html ['div]) "<div></div>")))
+    (is (= (str (html [:div])) "<div></div>"))
+    (is (= (str (html ["div"])) "<div></div>"))
+    (is (= (str (html ['div])) "<div></div>")))
   (testing "tag syntax sugar"
-    (is (= (html [:div#foo]) "<div id=\"foo\"></div>"))
-    (is (= (html [:div.foo]) "<div class=\"foo\"></div>"))
-    (is (= (html [:div.foo (str "bar" "baz")])
+    (is (= (str (html [:div#foo])) "<div id=\"foo\"></div>"))
+    (is (= (str (html [:div.foo])) "<div class=\"foo\"></div>"))
+    (is (= (str (html [:div.foo (str "bar" "baz")]))
            "<div class=\"foo\">barbaz</div>"))
-    (is (= (html [:div.a.b]) "<div class=\"a b\"></div>"))
-    (is (= (html [:div.a.b.c]) "<div class=\"a b c\"></div>"))
-    (is (= (html [:div#foo.bar.baz])
+    (is (= (str (html [:div.a.b])) "<div class=\"a b\"></div>"))
+    (is (= (str (html [:div.a.b.c])) "<div class=\"a b c\"></div>"))
+    (is (= (str (html [:div#foo.bar.baz]))
            "<div class=\"bar baz\" id=\"foo\"></div>"))))
 
 (deftest tag-contents
   (testing "empty tags"
-    (is (= (html [:div]) "<div></div>"))
-    (is (= (html [:h1]) "<h1></h1>"))
-    (is (= (html [:script]) "<script></script>"))
-    (is (= (html [:text]) "<text></text>"))
-    (is (= (html [:a]) "<a></a>"))
-    (is (= (html [:iframe]) "<iframe></iframe>"))
-    (is (= (html [:title]) "<title></title>"))
-    (is (= (html [:section]) "<section></section>"))
-    (is (= (html [:select]) "<select></select>"))
-    (is (= (html [:object]) "<object></object>"))
-    (is (= (html [:video]) "<video></video>")))
+    (is (= (str (html [:div])) "<div></div>"))
+    (is (= (str (html [:h1])) "<h1></h1>"))
+    (is (= (str (html [:script])) "<script></script>"))
+    (is (= (str (html [:text])) "<text></text>"))
+    (is (= (str (html [:a])) "<a></a>"))
+    (is (= (str (html [:iframe])) "<iframe></iframe>"))
+    (is (= (str (html [:title])) "<title></title>"))
+    (is (= (str (html [:section])) "<section></section>"))
+    (is (= (str (html [:select])) "<select></select>"))
+    (is (= (str (html [:object])) "<object></object>"))
+    (is (= (str (html [:video])) "<video></video>")))
   (testing "void tags"
-    (is (= (html [:br]) "<br />"))
-    (is (= (html [:link]) "<link />"))
-    (is (= (html [:colgroup {:span 2}]) "<colgroup span=\"2\"></colgroup>"))
-    (is (= (html [:colgroup [:col]]) "<colgroup><col /></colgroup>")))
+    (is (= (str (html [:br])) "<br />"))
+    (is (= (str (html [:link])) "<link />"))
+    (is (= (str (html [:colgroup {:span 2}])) "<colgroup span=\"2\"></colgroup>"))
+    (is (= (str (html [:colgroup [:col]])) "<colgroup><col /></colgroup>")))
   (testing "tags containing text"
-    (is (= (html [:text "Lorem Ipsum"]) "<text>Lorem Ipsum</text>")))
+    (is (= (str (html [:text "Lorem Ipsum"])) "<text>Lorem Ipsum</text>")))
   (testing "contents are concatenated"
-    (is (= (html [:body "foo" "bar"]) "<body>foobar</body>"))
-    (is (= (html [:body [:p] [:br]]) "<body><p></p><br /></body>")))
+    (is (= (str (html [:body "foo" "bar"])) "<body>foobar</body>"))
+    (is (= (str (html [:body [:p] [:br]])) "<body><p></p><br /></body>")))
   (testing "seqs are expanded"
-    (is (= (html [:body (list "foo" "bar")]) "<body>foobar</body>"))
-    (is (= (html (list [:p "a"] [:p "b"])) "<p>a</p><p>b</p>")))
+    (is (= (str (html [:body (list "foo" "bar")])) "<body>foobar</body>"))
+    (is (= (str (html (list [:p "a"] [:p "b"]))) "<p>a</p><p>b</p>")))
   (testing "keywords are turned into strings"
-    (is (= (html [:div :foo]) "<div>foo</div>")))
+    (is (= (str (html [:div :foo])) "<div>foo</div>")))
   (testing "vecs don't expand - error if vec doesn't have tag name"
     (is (thrown? IllegalArgumentException
                  (html (vector [:p "a"] [:p "b"])))))
   (testing "tags can contain tags"
-    (is (= (html [:div [:p]]) "<div><p></p></div>"))
-    (is (= (html [:div [:b]]) "<div><b></b></div>"))
-    (is (= (html [:p [:span [:a "foo"]]])
+    (is (= (str (html [:div [:p]])) "<div><p></p></div>"))
+    (is (= (str (html [:div [:b]])) "<div><b></b></div>"))
+    (is (= (str (html [:p [:span [:a "foo"]]]))
            "<p><span><a>foo</a></span></p>"))))
 
 (deftest tag-attributes
   (testing "tag with blank attribute map"
-    (is (= (html [:xml {}]) "<xml></xml>")))
+    (is (= (str (html [:xml {}])) "<xml></xml>")))
   (testing "tag with populated attribute map"
-    (is (= (html [:xml {:a "1", :b "2"}]) "<xml a=\"1\" b=\"2\"></xml>"))
-    (is (= (html [:img {"id" "foo"}]) "<img id=\"foo\" />"))
-    (is (= (html [:img {'id "foo"}]) "<img id=\"foo\" />"))
-    (is (= (html [:xml {:a "1", 'b "2", "c" "3"}])
+    (is (= (str (html [:xml {:a "1", :b "2"}])) "<xml a=\"1\" b=\"2\"></xml>"))
+    (is (= (str (html [:img {"id" "foo"}])) "<img id=\"foo\" />"))
+    (is (= (str (html [:img {'id "foo"}])) "<img id=\"foo\" />"))
+    (is (= (str (html [:xml {:a "1", 'b "2", "c" "3"}]))
            "<xml a=\"1\" b=\"2\" c=\"3\"></xml>")))
   (testing "attribute values are escaped"
-    (is (= (html [:div {:id "\""}]) "<div id=\"&quot;\"></div>")))
+    (is (= (str (html [:div {:id "\""}])) "<div id=\"&quot;\"></div>")))
   (testing "boolean attributes"
-    (is (= (html [:input {:type "checkbox" :checked true}])
+    (is (= (str (html [:input {:type "checkbox" :checked true}]))
            "<input checked=\"checked\" type=\"checkbox\" />"))
-    (is (= (html [:input {:type "checkbox" :checked false}])
+    (is (= (str (html [:input {:type "checkbox" :checked false}]))
            "<input type=\"checkbox\" />")))
   (testing "nil attributes"
-    (is (= (html [:span {:class nil} "foo"])
+    (is (= (str (html [:span {:class nil} "foo"]))
            "<span>foo</span>")))
   (testing "resolving conflicts between attributes in the map and tag"
-    (is (= (html [:div.foo {:class "bar"} "baz"])
+    (is (= (str (html [:div.foo {:class "bar"} "baz"]))
            "<div class=\"foo bar\">baz</div>"))
-    (is (= (html [:div#bar.foo {:id "baq"} "baz"])
+    (is (= (str (html [:div#bar.foo {:id "baq"} "baz"]))
            "<div class=\"foo\" id=\"baq\">baz</div>"))))
 
 (deftest compiled-tags
   (testing "tag content can be vars"
-    (is (= (let [x "foo"] (html [:span x])) "<span>foo</span>")))
+    (is (= (let [x "foo"] (str (html [:span x]))) "<span>foo</span>")))
   (testing "tag content can be forms"
-    (is (= (html [:span (str (+ 1 1))]) "<span>2</span>"))
-    (is (= (html [:span ({:foo "bar"} :foo)]) "<span>bar</span>")))
+    (is (= (str (html [:span (str (+ 1 1))])) "<span>2</span>"))
+    (is (= (str (html [:span ({:foo "bar"} :foo)])) "<span>bar</span>")))
   (testing "attributes can contain vars"
     (let [x "foo"]
-      (is (= (html [:xml {:x x}]) "<xml x=\"foo\"></xml>"))
-      (is (= (html [:xml {x "x"}]) "<xml foo=\"x\"></xml>"))
-      (is (= (html [:xml {:x x} "bar"]) "<xml x=\"foo\">bar</xml>"))))
+      (is (= (str (html [:xml {:x x}])) "<xml x=\"foo\"></xml>"))
+      (is (= (str (html [:xml {x "x"}])) "<xml foo=\"x\"></xml>"))
+      (is (= (str (html [:xml {:x x} "bar"])) "<xml x=\"foo\">bar</xml>"))))
   (testing "attributes are evaluated"
-    (is (= (html [:img {:src (str "/foo" "/bar")}])
+    (is (= (str (html [:img {:src (str "/foo" "/bar")}]))
            "<img src=\"/foo/bar\" />"))
-    (is (= (html [:div {:id (str "a" "b")} (str "foo")])
+    (is (= (str (html [:div {:id (str "a" "b")} (str "foo")]))
            "<div id=\"ab\">foo</div>")))
   (testing "type hints"
     (let [string "x"]
-      (is (= (html [:span ^String string]) "<span>x</span>"))))
+      (is (= (str (html [:span ^String string])) "<span>x</span>"))))
   (testing "optimized forms"
-    (is (= (html [:ul (for [n (range 3)]
-                        [:li n])])
+    (is (= (str (html [:ul (for [n (range 3)]
+                             [:li n])]))
            "<ul><li>0</li><li>1</li><li>2</li></ul>"))
-    (is (= (html [:div (if true
-                         [:span "foo"]
-                         [:span "bar"])])
+    (is (= (str (html [:div (if true
+                              [:span "foo"]
+                              [:span "bar"])]))
            "<div><span>foo</span></div>")))
   (testing "values are evaluated only once"
     (let [times-called (atom 0)
@@ -114,16 +121,50 @@
 
 (deftest render-modes
   (testing "closed tag"
-    (is (= (html [:p] [:br]) "<p></p><br />"))
-    (is (= (html {:mode :xhtml} [:p] [:br]) "<p></p><br />"))
-    (is (= (html {:mode :html} [:p] [:br]) "<p></p><br>"))
-    (is (= (html {:mode :xml} [:p] [:br]) "<p /><br />"))
-    (is (= (html {:mode :sgml} [:p] [:br]) "<p><br>")))
+    (is (= (str (html [:p] [:br])) "<p></p><br />"))
+    (is (= (str (html {:mode :xhtml} [:p] [:br])) "<p></p><br />"))
+    (is (= (str (html {:mode :html} [:p] [:br])) "<p></p><br>"))
+    (is (= (str (html {:mode :xml} [:p] [:br])) "<p /><br />"))
+    (is (= (str (html {:mode :sgml} [:p] [:br])) "<p><br>")))
   (testing "boolean attributes"
-    (is (= (html {:mode :xml} [:input {:type "checkbox" :checked true}])
+    (is (= (str (html {:mode :xml} [:input {:type "checkbox" :checked true}]))
            "<input checked=\"checked\" type=\"checkbox\" />"))
-    (is (= (html {:mode :sgml} [:input {:type "checkbox" :checked true}])
+    (is (= (str (html {:mode :sgml} [:input {:type "checkbox" :checked true}]))
            "<input checked type=\"checkbox\">")))
   (testing "laziness and binding scope"
-    (is (= (html {:mode :sgml} [:html [:link] (list [:link])])
+    (is (= (str (html {:mode :sgml} [:html [:link] (list [:link])]))
            "<html><link><link></html>"))))
+
+(deftest auto-escaping
+  (testing "literals"
+    (is (= (str (html "<>")) "&lt;&gt;"))
+    (is (= (str (html :<>)) "&lt;&gt;"))
+    (is (= (str (html ^String (str "<>"))) "&lt;&gt;"))
+    (is (= (str (html {"<foo>" "<bar>"})) "{&quot;&lt;foo&gt;&quot; &quot;&lt;bar&gt;&quot;}"))
+    (is (= (str (html #{"<>"})) "#{&quot;&lt;&gt;&quot;}"))
+    (is (= (str (html 1)) "1"))
+    (is (= (str (html ^Number (+ 1 1))) "2")))
+  (testing "non-literals"
+    (is (= (str (html (list [:p "<foo>"] [:p "<bar>"])))
+           "<p>&lt;foo&gt;</p><p>&lt;bar&gt;</p>"))
+    (is (= (str (html ((constantly "<foo>")))) "&lt;foo&gt;"))
+    (is (= (let [x "<foo>"] (str (html x))) "&lt;foo&gt;")))
+  (testing "optimized forms"
+    (is (= (str (html (if true :<foo> :<bar>))) "&lt;foo&gt;"))
+    (is (= (str (html (for [x [:<foo>]] x))) "&lt;foo&gt;")))
+  (testing "elements"
+    (is (= (str (html [:p "<>"])) "<p>&lt;&gt;</p>"))
+    (is (= (str (html [:p :<>])) "<p>&lt;&gt;</p>"))
+    (is (= (str (html [:p {} {"<foo>" "<bar>"}]))
+           "<p>{&quot;&lt;foo&gt;&quot; &quot;&lt;bar&gt;&quot;}</p>"))
+    (is (= (str (html [:p {} #{"<foo>"}]))
+           "<p>#{&quot;&lt;foo&gt;&quot;}</p>"))
+    (is (= (str (html [:p {:class "<\">"}]))
+           "<p class=\"&lt;&quot;&gt;\"></p>"))
+    (is (= (str (html [:ul [:li "<foo>"]]))
+           "<ul><li>&lt;foo&gt;</li></ul>")))
+  (testing "raw strings"
+    (is (= (str (html (raw-string "<foo>"))) "<foo>"))
+    (is (= (str (html [:p (raw-string "<foo>")])) "<p><foo></p>"))
+    (is (= (str (html (html [:p "<>"]))) "<p>&lt;&gt;</p>"))
+    (is (= (str (html [:ul (html [:li "<>"])])) "<ul><li>&lt;&gt;</li></ul>"))))

--- a/test/hiccup/test/def.clj
+++ b/test/hiccup/test/def.clj
@@ -5,13 +5,13 @@
 (deftest test-defhtml
   (testing "basic html function"
     (defhtml basic-fn [x] [:span x])
-    (is (= (basic-fn "foo") "<span>foo</span>")))
+    (is (= (str (basic-fn "foo")) "<span>foo</span>")))
   (testing "html function with overloads"
     (defhtml overloaded-fn
       ([x] [:span x])
       ([x y] [:span x [:div y]]))
-    (is (= (overloaded-fn "foo") "<span>foo</span>"))
-    (is (= (overloaded-fn "foo" "bar")
+    (is (= (str (overloaded-fn "foo")) "<span>foo</span>"))
+    (is (= (str (overloaded-fn "foo" "bar"))
            "<span>foo<div>bar</div></span>"))))
 
 (deftest test-defelem

--- a/test/hiccup/test/form.clj
+++ b/test/hiccup/test/form.clj
@@ -4,59 +4,59 @@
         hiccup.form))
 
 (deftest test-hidden-field
-  (is (= (html (hidden-field :foo "bar"))
+  (is (= (str (html (hidden-field :foo "bar")))
          "<input id=\"foo\" name=\"foo\" type=\"hidden\" value=\"bar\" />")))
 
 (deftest test-hidden-field-with-extra-atts
-  (is (= (html (hidden-field {:class "classy"} :foo "bar"))
+  (is (= (str (html (hidden-field {:class "classy"} :foo "bar")))
          "<input class=\"classy\" id=\"foo\" name=\"foo\" type=\"hidden\" value=\"bar\" />")))
 
 (deftest test-text-field
-  (is (= (html (text-field :foo))
+  (is (= (str (html (text-field :foo)))
          "<input id=\"foo\" name=\"foo\" type=\"text\" />")))
 
 (deftest test-text-field-with-extra-atts
-  (is (= (html (text-field {:class "classy"} :foo "bar"))
+  (is (= (str (html (text-field {:class "classy"} :foo "bar")))
          "<input class=\"classy\" id=\"foo\" name=\"foo\" type=\"text\" value=\"bar\" />")))
 
 (deftest test-check-box
-  (is (= (html (check-box :foo true))
+  (is (= (str (html (check-box :foo true)))
          (str "<input checked=\"checked\" id=\"foo\" name=\"foo\""
               " type=\"checkbox\" value=\"true\" />"))))
 
 (deftest test-check-box-with-extra-atts
-  (is (= (html (check-box {:class "classy"} :foo true 1))
+  (is (= (str (html (check-box {:class "classy"} :foo true 1)))
          (str "<input checked=\"checked\" class=\"classy\" id=\"foo\" name=\"foo\""
               " type=\"checkbox\" value=\"1\" />"))))
 
 (deftest test-password-field
-  (is (= (html (password-field :foo "bar"))
+  (is (= (str (html (password-field :foo "bar")))
          "<input id=\"foo\" name=\"foo\" type=\"password\" value=\"bar\" />")))
 
 (deftest test-password-field-with-extra-atts
-  (is (= (html (password-field {:class "classy"} :foo "bar"))
+  (is (= (str (html (password-field {:class "classy"} :foo "bar")))
          "<input class=\"classy\" id=\"foo\" name=\"foo\" type=\"password\" value=\"bar\" />")))
 
 (deftest test-email-field
-  (is (= (html (email-field :foo "bar"))
+  (is (= (str (html (email-field :foo "bar")))
          "<input id=\"foo\" name=\"foo\" type=\"email\" value=\"bar\" />")))
 
 (deftest test-email-field-with-extra-atts
-  (is (= (html (email-field {:class "classy"} :foo "bar"))
+  (is (= (str (html (email-field {:class "classy"} :foo "bar")))
          "<input class=\"classy\" id=\"foo\" name=\"foo\" type=\"email\" value=\"bar\" />")))
 
 (deftest test-radio-button
-  (is (= (html (radio-button :foo true 1))
+  (is (= (str (html (radio-button :foo true 1)))
          (str "<input checked=\"checked\" id=\"foo-1\" name=\"foo\""
               " type=\"radio\" value=\"1\" />"))))
 
 (deftest test-radio-button-with-extra-atts
-  (is (= (html (radio-button {:class "classy"} :foo true 1))
+  (is (= (str (html (radio-button {:class "classy"} :foo true 1)))
          (str "<input checked=\"checked\" class=\"classy\" id=\"foo-1\" name=\"foo\""
               " type=\"radio\" value=\"1\" />"))))
 
 (deftest test-select-options
-  (are [x y] (= (html x) y)
+  (are [x y] (= (str (html x)) y)
     (select-options ["foo" "bar" "baz"])
       "<option>foo</option><option>bar</option><option>baz</option>"
     (select-options ["foo" "bar"] "bar")
@@ -79,107 +79,107 @@
   (let [options ["op1" "op2"]
         selected "op1"
         select-options (html (select-options options selected))]
-    (is (= (html (drop-down :foo options selected))
+    (is (= (str (html (drop-down :foo options selected)))
            (str "<select id=\"foo\" name=\"foo\">" select-options "</select>")))))
 
 (deftest test-drop-down-with-extra-atts
   (let [options ["op1" "op2"]
         selected "op1"
         select-options (html (select-options options selected))]
-    (is (= (html (drop-down {:class "classy"} :foo options selected))
+    (is (= (str (html (drop-down {:class "classy"} :foo options selected)))
            (str "<select class=\"classy\" id=\"foo\" name=\"foo\">"
                 select-options "</select>")))))
 
 (deftest test-text-area
-  (is (= (html (text-area :foo "bar"))
+  (is (= (str (html (text-area :foo "bar")))
          "<textarea id=\"foo\" name=\"foo\">bar</textarea>")))
 
 (deftest test-text-area-field-with-extra-atts
-  (is (= (html (text-area {:class "classy"} :foo "bar"))
+  (is (= (str (html (text-area {:class "classy"} :foo "bar")))
          "<textarea class=\"classy\" id=\"foo\" name=\"foo\">bar</textarea>")))
 
 (deftest test-text-area-escapes
-  (is (= (html (text-area :foo "bar</textarea>"))
+  (is (= (str (html (text-area :foo "bar</textarea>")))
          "<textarea id=\"foo\" name=\"foo\">bar&lt;/textarea&gt;</textarea>")))
 
 (deftest test-file-field
-  (is (= (html (file-upload :foo))
+  (is (= (str (html (file-upload :foo)))
          "<input id=\"foo\" name=\"foo\" type=\"file\" />")))
 
 (deftest test-file-field-with-extra-atts
-  (is (= (html (file-upload {:class "classy"} :foo))
+  (is (= (str (html (file-upload {:class "classy"} :foo)))
          (str "<input class=\"classy\" id=\"foo\" name=\"foo\""
               " type=\"file\" />"))))
 
 (deftest test-label
-  (is (= (html (label :foo "bar"))
+  (is (= (str (html (label :foo "bar")))
          "<label for=\"foo\">bar</label>")))
 
 (deftest test-label-with-extra-atts
-  (is (= (html (label {:class "classy"} :foo "bar"))
+  (is (= (str (html (label {:class "classy"} :foo "bar")))
          "<label class=\"classy\" for=\"foo\">bar</label>")))
 
 (deftest test-submit
-  (is (= (html (submit-button "bar"))
+  (is (= (str (html (submit-button "bar")))
          "<input type=\"submit\" value=\"bar\" />")))
 
 (deftest test-submit-button-with-extra-atts
-  (is (= (html (submit-button {:class "classy"} "bar"))
+  (is (= (str (html (submit-button {:class "classy"} "bar")))
          "<input class=\"classy\" type=\"submit\" value=\"bar\" />")))
 
 (deftest test-reset-button
-  (is (= (html (reset-button "bar"))
+  (is (= (str (html (reset-button "bar")))
          "<input type=\"reset\" value=\"bar\" />")))
 
 (deftest test-reset-button-with-extra-atts
-  (is (= (html (reset-button {:class "classy"} "bar"))
+  (is (= (str (html (reset-button {:class "classy"} "bar")))
          "<input class=\"classy\" type=\"reset\" value=\"bar\" />")))
 
 (deftest test-form-to
-  (is (= (html (form-to [:post "/path"] "foo" "bar"))
+  (is (= (str (html (form-to [:post "/path"] "foo" "bar")))
          "<form action=\"/path\" method=\"POST\">foobar</form>")))
 
 (deftest test-form-to-with-hidden-method
-  (is (= (html (form-to [:put "/path"] "foo" "bar"))
+  (is (= (str (html (form-to [:put "/path"] "foo" "bar")))
          (str "<form action=\"/path\" method=\"POST\">"
               "<input id=\"_method\" name=\"_method\" type=\"hidden\" value=\"PUT\" />"
               "foobar</form>"))))
 
 (deftest test-form-to-with-extr-atts
-  (is (= (html (form-to {:class "classy"} [:post "/path"] "foo" "bar"))
+  (is (= (str (html (form-to {:class "classy"} [:post "/path"] "foo" "bar")))
          "<form action=\"/path\" class=\"classy\" method=\"POST\">foobar</form>")))
 
 (deftest test-with-group
   (testing "hidden-field"
-    (is (= (html (with-group :foo (hidden-field :bar "val")))
+    (is (= (str (html (with-group :foo (hidden-field :bar "val"))))
            "<input id=\"foo-bar\" name=\"foo[bar]\" type=\"hidden\" value=\"val\" />")))
   (testing "text-field"
-    (is (= (html (with-group :foo (text-field :bar)))
+    (is (= (str (html (with-group :foo (text-field :bar))))
            "<input id=\"foo-bar\" name=\"foo[bar]\" type=\"text\" />")))
   (testing "checkbox"
-    (is (= (html (with-group :foo (check-box :bar)))
+    (is (= (str (html (with-group :foo (check-box :bar))))
            "<input id=\"foo-bar\" name=\"foo[bar]\" type=\"checkbox\" value=\"true\" />")))
   (testing "password-field"
-    (is (= (html (with-group :foo (password-field :bar)))
+    (is (= (str (html (with-group :foo (password-field :bar))))
            "<input id=\"foo-bar\" name=\"foo[bar]\" type=\"password\" />")))
   (testing "radio-button"
-    (is (= (html (with-group :foo (radio-button :bar false "val")))
+    (is (= (str (html (with-group :foo (radio-button :bar false "val"))))
            "<input id=\"foo-bar-val\" name=\"foo[bar]\" type=\"radio\" value=\"val\" />")))
   (testing "drop-down"
-    (is (= (html (with-group :foo (drop-down :bar [])))
+    (is (= (str (html (with-group :foo (drop-down :bar []))))
            (str "<select id=\"foo-bar\" name=\"foo[bar]\"></select>"))))
   (testing "text-area"
-    (is (= (html (with-group :foo (text-area :bar)))
+    (is (= (str (html (with-group :foo (text-area :bar))))
            (str "<textarea id=\"foo-bar\" name=\"foo[bar]\"></textarea>"))))
   (testing "file-upload"
-    (is (= (html (with-group :foo (file-upload :bar)))
+    (is (= (str (html (with-group :foo (file-upload :bar))))
            "<input id=\"foo-bar\" name=\"foo[bar]\" type=\"file\" />")))
   (testing "label"
-    (is (= (html (with-group :foo (label :bar "Bar")))
+    (is (= (str (html (with-group :foo (label :bar "Bar"))))
            "<label for=\"foo-bar\">Bar</label>")))
   (testing "multiple with-groups"
-    (is (= (html (with-group :foo (with-group :bar (text-field :baz))))
+    (is (= (str (html (with-group :foo (with-group :bar (text-field :baz)))))
            "<input id=\"foo-bar-baz\" name=\"foo[bar][baz]\" type=\"text\" />")))
   (testing "multiple elements"
-    (is (= (html (with-group :foo (label :bar "Bar") (text-field :var)))
+    (is (= (str (html (with-group :foo (label :bar "Bar") (text-field :var))))
            "<label for=\"foo-bar\">Bar</label><input id=\"foo-var\" name=\"foo[var]\" type=\"text\" />"))))

--- a/test/hiccup/test/middleware.clj
+++ b/test/hiccup/test/middleware.clj
@@ -7,7 +7,7 @@
 (defn test-handler [request]
   {:status  200
    :headers {"Content-Type" "text/html"}
-   :body    (html [:html [:body (link-to "/bar" "bar")]])})
+   :body    (str (html [:html [:body (link-to "/bar" "bar")]]))})
 
 (deftest test-wrap-base-url
   (let [resp ((wrap-base-url test-handler "/foo") {})]

--- a/test/hiccup/test/page.clj
+++ b/test/hiccup/test/page.clj
@@ -4,25 +4,25 @@
   (:import java.net.URI))
 
 (deftest html4-test
-  (is (= (html4 [:body [:p "Hello" [:br] "World"]])
+  (is (= (str (html4 [:body [:p "Hello" [:br] "World"]]))
          (str "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" "
               "\"http://www.w3.org/TR/html4/strict.dtd\">\n"
               "<html><body><p>Hello<br>World</p></body></html>"))))
 
 (deftest xhtml-test
-  (is (= (xhtml [:body [:p "Hello" [:br] "World"]])
+  (is (= (str (xhtml [:body [:p "Hello" [:br] "World"]]))
          (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
               "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "
               "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
               "<html xmlns=\"http://www.w3.org/1999/xhtml\">"
               "<body><p>Hello<br />World</p></body></html>")))
-  (is (= (xhtml {:lang "en"} [:body "Hello World"])
+  (is (= (str (xhtml {:lang "en"} [:body "Hello World"]))
          (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
               "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "
               "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
               "<html lang=\"en\" xml:lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\">"
               "<body>Hello World</body></html>")))
-  (is (= (xhtml {:encoding "ISO-8859-1"} [:body "Hello World"])
+  (is (= (str (xhtml {:encoding "ISO-8859-1"} [:body "Hello World"]))
          (str "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n"
               "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "
               "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
@@ -31,39 +31,39 @@
 
 (deftest html5-test
   (testing "HTML mode"
-    (is (= (html5 [:body [:p "Hello" [:br] "World"]])
+    (is (= (str (html5 [:body [:p "Hello" [:br] "World"]]))
            "<!DOCTYPE html>\n<html><body><p>Hello<br>World</p></body></html>"))
-    (is (= (html5 {:lang "en"} [:body "Hello World"])
+    (is (= (str (html5 {:lang "en"} [:body "Hello World"]))
            "<!DOCTYPE html>\n<html lang=\"en\"><body>Hello World</body></html>"))
-    (is (= (html5 {:prefix "og: http://ogp.me/ns#"}
-                  [:body "Hello World"])
+    (is (= (str (html5 {:prefix "og: http://ogp.me/ns#"}
+                       [:body "Hello World"]))
            (str "<!DOCTYPE html>\n"
                 "<html prefix=\"og: http://ogp.me/ns#\">"
                 "<body>Hello World</body></html>")))
-    (is (= (html5 {:prefix "og: http://ogp.me/ns#"
-                   :lang "en"}
-                  [:body "Hello World"])
+    (is (= (str (html5 {:prefix "og: http://ogp.me/ns#"
+                        :lang "en"}
+                       [:body "Hello World"]))
            (str "<!DOCTYPE html>\n"
                 "<html lang=\"en\" prefix=\"og: http://ogp.me/ns#\">"
                 "<body>Hello World</body></html>"))))
   (testing "XML mode"
-    (is (= (html5 {:xml? true} [:body [:p "Hello" [:br] "World"]])
+    (is (= (str (html5 {:xml? true} [:body [:p "Hello" [:br] "World"]]))
            (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                 "<!DOCTYPE html>\n<html xmlns=\"http://www.w3.org/1999/xhtml\">"
                 "<body><p>Hello<br />World</p></body></html>")))
-    (is (= (html5 {:xml? true, :lang "en"} [:body "Hello World"])
+    (is (= (str (html5 {:xml? true, :lang "en"} [:body "Hello World"]))
            (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                 "<!DOCTYPE html>\n"
                 "<html lang=\"en\" xml:lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\">"
                 "<body>Hello World</body></html>")))
-    (is (= (html5 {:xml? true,
-                   "xml:og" "http://ogp.me/ns#"} [:body "Hello World"])
+    (is (= (str (html5 {:xml? true,
+                        "xml:og" "http://ogp.me/ns#"} [:body "Hello World"]))
            (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                 "<!DOCTYPE html>\n"
                 "<html xml:og=\"http://ogp.me/ns#\" xmlns=\"http://www.w3.org/1999/xhtml\">"
                 "<body>Hello World</body></html>")))    
-    (is (= (html5 {:xml? true, :lang "en"
-                   "xml:og" "http://ogp.me/ns#"} [:body "Hello World"])
+    (is (= (str (html5 {:xml? true, :lang "en"
+                        "xml:og" "http://ogp.me/ns#"} [:body "Hello World"]))
            (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                 "<!DOCTYPE html>\n"
                 "<html lang=\"en\" xml:lang=\"en\" xml:og=\"http://ogp.me/ns#\" xmlns=\"http://www.w3.org/1999/xhtml\">"


### PR DESCRIPTION
This commit implements issue #114 (Safe HTML by default). It introduces
a few breaking changes:

1. Since all strings are escaped by default, adding HTML markup from
string literals or expressions will not work. Use `hiccup.util/raw-str`
to prevent these values from being escaped.

2. `hiccup.util/escape-html`, `hiccup.core/h` and `hiccup.core/html`
returns a RawString object instead of a String. They can be converted to
java.lang.String with the built-in `str` function.

Note that unlike `hiccup.util/html`, macros in `hiccup.page` (`html4`,
`html5`, `xhtml`) *still* return a string so that their result can be
passed directly to Ring. In the rare cases when the output is embedded
to another html page (e.g. into an iframe) it should be also tagged with
`hiccup.util/raw-str`.