### PR TITLE
permit raw attribute values

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -14,7 +14,11 @@
   (if (xml-mode?) " />" ">"))
 
 (defn- xml-attribute [name value]
-  (str " " (util/as-str name) "=\"" (util/escape-html value) "\""))
+  (str " " (util/as-str name) "=\""
+       (if (util/raw-string? value)
+         value
+         (util/escape-html value))
+       "\""))
 
 (defn- render-attribute [[name value]]
   (cond

--- a/test/hiccup/core_test.clj
+++ b/test/hiccup/core_test.clj
@@ -168,6 +168,8 @@
     (is (= (str (html [:p (util/raw-string "<foo>")])) "<p><foo></p>"))
     (is (= (str (html (html [:p "<>"]))) "<p>&lt;&gt;</p>"))
     (is (= (str (html [:ul (html [:li "<>"])])) "<ul><li>&lt;&gt;</li></ul>"))
+    (is (= (str (html "'")) "&apos;"))
+    (is (= (str (html [:p {:data-x "'"}])) "<p data-x=\"&apos;\"></p>"))
     (is (= (str (html [:p {:data-x (util/raw-string "'")}]))
            "<p data-x=\"'\"></p>"))))
 

--- a/test/hiccup/core_test.clj
+++ b/test/hiccup/core_test.clj
@@ -167,7 +167,9 @@
     (is (= (str (html (util/raw-string "<foo>"))) "<foo>"))
     (is (= (str (html [:p (util/raw-string "<foo>")])) "<p><foo></p>"))
     (is (= (str (html (html [:p "<>"]))) "<p>&lt;&gt;</p>"))
-    (is (= (str (html [:ul (html [:li "<>"])])) "<ul><li>&lt;&gt;</li></ul>"))))
+    (is (= (str (html [:ul (html [:li "<>"])])) "<ul><li>&lt;&gt;</li></ul>"))
+    (is (= (str (html [:p {:data-x (util/raw-string "'")}]))
+           "<p data-x=\"'\"></p>"))))
 
 (deftest backward-compatibility
   (is (= (str (html [:span (h "<>")])) "<span>&lt;&gt;</span>")))


### PR DESCRIPTION
some attributes require values which get auto-escaped, e.g. 

```
<meta http-equiv="Content-Security-Policy" 
   content="default-src https://cdn.example.net; child-src 'none'; object-src 'none'">
```

this PR permits `hiccup.util/raw-string` to be used on attribute values