### PR TITLE
Allow keywords in style maps

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -24,7 +24,7 @@
 
 (defn- render-style-map [value]
   (->> value
-       (map (fn [[k v]] (str (util/as-str k) ":" v ";")))
+       (map (fn [[k v]] (str (util/as-str k) ":" (util/as-str v) ";")))
        (sort)
        (apply str)))
 

--- a/test/hiccup2/core_test.clj
+++ b/test/hiccup2/core_test.clj
@@ -88,8 +88,9 @@
     (is (= (str (html [:span {:class "baz bar"} "foo"]))
            "<span class=\"baz bar\">foo</span>")))
   (testing "map attributes"
-    (is (= (str (html [:span {:style {:color "red" :opacity "100%"}} "foo"]))
-           "<span style=\"color:red;opacity:100%;\">foo</span>")))
+    (is (= (str (html [:span {:style {:background-color :blue, :color "red",
+                                      :line-width 1.2, :opacity "100%"}} "foo"]))
+           "<span style=\"background-color:blue;color:red;line-width:1.2;opacity:100%;\">foo</span>")))
   (testing "resolving conflicts between attributes in the map and tag"
     (is (= (str (html [:div.foo {:class "bar"} "baz"]))
            "<div class=\"foo bar\">baz</div>"))


### PR DESCRIPTION
Reagent allows keywords as CSS attribute values such as

{:style {:color :red}}

Hiccup already supports this for top-level DOM node attributes. This commit
extends this feature to style maps.