### PR TITLE
precompile let and when forms

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -166,6 +166,18 @@
   [[_ condition & body]]
   `(if ~condition ~@(for [x body] (compile-html x))))
 
+(defmethod compile-form "when"
+  [[_ condition & body]]
+  `(when ~condition
+     ~@(butlast body)
+     ~(compile-html (last body))))
+
+(defmethod compile-form "let"
+  [[_ bindings & body]]
+  `(let ~bindings
+     ~@(butlast body)
+     ~(compile-html (last body))))
+
 (defmethod compile-form :default
   [expr]
   `(render-html ~expr))


### PR DESCRIPTION
Currently only `if` and `for` are pre-compiled by `hiccup.compiler`. Added `let` and `when` since those are the most common I have as well and they fall back to interpreted mode.

Might be useful to add `cond`, `case`, `condp`?