### PR TITLE
Fixes #143 tag classes combined with non-literal class attributes

### DIFF
--- a/test/hiccup/core_test.clj
+++ b/test/hiccup/core_test.clj
@@ -110,7 +110,11 @@
     (let [times-called (atom 0)
           foo #(swap! times-called inc)]
       (html [:div (foo)])
-      (is (= @times-called 1)))))
+      (is (= @times-called 1))))
+  (testing "defer evaluation of non-literal class names when combined with tag classes"
+    (let [x "attr-class"]
+      (is  (= (html [:div.tag-class {:class x}])
+              "<div class=\"tag-class attr-class\"></div>")))))
 
 (deftest render-modes
   (testing "closed tag"


### PR DESCRIPTION
Hello James,

This PR is a left-over of the Dutch Clojure group bug hunt session. It defers the construction of the class tag of an element till runtime if the class value is a symbol
It would otherwise evaluate the symbol at compile time if there are also classes specified on the tag name, throwing an error.
I'm not sure if there are other cases where this behaviour could also happen.

