### PR TITLE
Support reagent-style form-1 and form-2 components

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -110,7 +110,10 @@
 (defn normalize-element
   "Ensure an element vector is of the form [tag-name attrs content]." 
   [[tag & content :as tag-content]]
-  (normalize-element* (if (fn? tag) (apply tag content) tag-content) merge-attributes))
+  (normalize-element* (if (fn? tag)
+                        (let [r (apply tag content)]
+                          (if (fn? r) (apply r content) r))
+                        tag-content) merge-attributes))
 
 (defn- normalize-element-form
   [[tag & content :as tag-content]]

--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -110,7 +110,7 @@
 (defn normalize-element
   "Ensure an element vector is of the form [tag-name attrs content]." 
   [[tag & content :as tag-content]]
-  (normalize-element* tag-content merge-attributes))
+  (normalize-element* (if (fn? tag) (apply tag content) tag-content) merge-attributes))
 
 (defn- normalize-element-form
   [[tag & content :as tag-content]]

--- a/test/hiccup2/core_test.clj
+++ b/test/hiccup2/core_test.clj
@@ -219,4 +219,14 @@
     (defn greet-comp [greeting]
       [:h1 greeting])
     (is (= (str (html [hello-comp])) "<h1>Hello World</h1>"))
+    (is (= (str (html [greet-comp "Hello Friend"])) "<h1>Hello Friend</h1>")))
+
+  (testing "form-2"
+    (defn hello-comp []
+      (fn []
+        [:h1 "Hello World"]))
+    (defn greet-comp [greeting]
+      (fn [greeting]
+        [:h1 greeting]))
+    (is (= (str (html [hello-comp])) "<h1>Hello World</h1>"))
     (is (= (str (html [greet-comp "Hello Friend"])) "<h1>Hello Friend</h1>"))))

--- a/test/hiccup2/core_test.clj
+++ b/test/hiccup2/core_test.clj
@@ -211,3 +211,12 @@
            "<p><></p>"))
     (is (= (str (html {:escape-strings? false} [:p (raw "<>")]))
            "<p><></p>"))))
+
+(deftest reagent-components
+  (testing "form-1"
+    (defn hello-comp []
+      [:h1 "Hello World"])
+    (defn greet-comp [greeting]
+      [:h1 greeting])
+    (is (= (str (html [hello-comp])) "<h1>Hello World</h1>"))
+    (is (= (str (html [greet-comp "Hello Friend"])) "<h1>Hello Friend</h1>"))))


### PR DESCRIPTION
This adds support for rendering reagent-style form-1 and form-2 components. This has enabled us to do server-side rendering for our re-frame app in Clojure and letting react take over once it's been initialized.