### PR TITLE
Allow keywords in class vectors

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -77,7 +77,7 @@
   (cond
     (nil? class)    classes
     (string? class) (str classes " " class)
-    :else           (str classes " " (str/join " " class))))
+    :else           (str classes " " (str/join " " (map name class)))))
 
 (declare literal?)
 

--- a/test/hiccup/core_test.clj
+++ b/test/hiccup/core_test.clj
@@ -77,7 +77,18 @@
     (is (= (html [:div.foo {:class "bar"} "baz"])
            "<div class=\"foo bar\">baz</div>"))
     (is (= (html [:div#bar.foo {:id "baq"} "baz"])
-           "<div class=\"foo\" id=\"baq\">baz</div>"))))
+           "<div class=\"foo\" id=\"baq\">baz</div>")))
+  (testing "tag with vector class"
+    (is (= (html [:div.foo {:class ["bar"]} "baz"])
+           "<div class=\"foo bar\">baz</div>"))
+    (is (= (html [:div.foo {:class [:bar]} "baz"])
+           "<div class=\"foo bar\">baz</div>"))
+    (is (= (html [:div.foo {:class [:bar "box"]} "baz"])
+           "<div class=\"foo bar box\">baz</div>"))
+    (is (= (html [:div.foo {:class ["bar" "box"]} "baz"])
+           "<div class=\"foo bar box\">baz</div>"))
+    (is (= (html [:div.foo {:class [:bar :box]} "baz"])
+           "<div class=\"foo bar box\">baz</div>"))))
 
 (deftest compiled-tags
   (testing "tag content can be vars"


### PR DESCRIPTION
Currently when adding keywords to a class vector, the keywords get converted to string literally.
```clojure 
(html [:div {:class [:foo]}])
;;=> <div class=":foo"></div>
```
After PR:

```clojure 
(html [:div {:class [:foo]}])
;;=> <div class="foo"></div>
```
Not sure if this is desired, but this is also how it works in Reagent.