### PR TITLE
Use hiccup.util/as-str for attribute sequences

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -33,7 +33,7 @@
     (map? value)
       (render-style-map value)
     (sequential? value)
-      (str/join " " value)
+      (str/join " " (map util/as-str value))
     :else
       value))
 

--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -33,7 +33,7 @@
     (map? value)
       (render-style-map value)
     (sequential? value)
-      (str/join " " (map util/as-str value))
+      (str/join " " (map util/to-str value))
     :else
       value))
 


### PR DESCRIPTION
Use `hiccup.util/as-str` for each item in a sequence attribute. This would allow users to extend the `hiccup.util/ToString` protocol in attributes with a sequence. Which I personally need to render atoms / functions properly. My webpage still renders with this change, and tests didn't break. However I can't say if this change has no impact at all.