### PR TITLE
Fix keyword class names not converted to strings

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -33,7 +33,7 @@
     (map? value)
       (render-style-map value)
     (sequential? value)
-      (str/join " " value)
+      (str/join " " (map util/to-str value))
     :else
       value))
 

--- a/test/hiccup/core_test.clj
+++ b/test/hiccup/core_test.clj
@@ -58,6 +58,10 @@
   (testing "tag with blank attribute map"
     (is (= (html [:xml {}]) "<xml></xml>")))
   (testing "tag with populated attribute map"
+    (is (= (html [:xml {:a 123}]) "<xml a=\"123\"></xml>"))
+    (is (= (html [:xml {:a 'sym}]) "<xml a=\"sym\"></xml>"))
+    (is (= (html [:xml {:a :kw}]) "<xml a=\"kw\"></xml>"))
+    (is (= (html [:xml {:a [:kw :ns/ns-kw "str" 3 'sym]}]) "<xml a=\"kw ns-kw str 3 sym\"></xml>"))
     (is (= (html [:xml {:a "1", :b "2"}]) "<xml a=\"1\" b=\"2\"></xml>"))
     (is (= (html [:img {"id" "foo"}]) "<img id=\"foo\" />"))
     (is (= (html [:img {'id "foo"}]) "<img id=\"foo\" />"))
@@ -79,6 +83,8 @@
     (is (= (html [:div#bar.foo {:id "baq"} "baz"])
            "<div class=\"foo\" id=\"baq\">baz</div>")))
   (testing "tag with vector class"
+    (is (= (html [:div {:class [:bar]} "baz"])
+           "<div class=\"bar\">baz</div>"))
     (is (= (html [:div.foo {:class ["bar"]} "baz"])
            "<div class=\"foo bar\">baz</div>"))
     (is (= (html [:div.foo {:class [:bar]} "baz"])


### PR DESCRIPTION
When classes is nil, the merge code that converts keyword class names to strings is not being called. This commit ensures that the code gets called if there are any classes.

