### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ install:
   - curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > lein
   - sudo mv lein /usr/local/bin/lein
   - sudo chmod a+x /usr/local/bin/lein
+
+addons:
+  apt:
+    packages:
+      - openjdk-8-jdk 
   
 language: clojure
 script: lein test-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,12 @@
+os: linux
+arch:
+ - amd64
+ - ppc64le
+
+install:
+  - curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > lein
+  - sudo mv lein /usr/local/bin/lein
+  - sudo chmod a+x /usr/local/bin/lein
+  
 language: clojure
 script: lein test-all


### PR DESCRIPTION
Thank you for the code.
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
