### PR TITLE
Update to include-js to allow adding other element attributes

### DIFF
--- a/src/hiccup/page.clj
+++ b/src/hiccup/page.clj
@@ -78,7 +78,11 @@
   "Include a list of external javascript files."
   [& scripts]
   (for [script scripts]
-    [:script {:type "text/javascript", :src (util/to-uri script)}]))
+    (if (:src script)
+      [:script
+       (merge {:type "text/javascript", :src (util/to-uri (:src script))}
+              (dissoc script :src))]
+      [:script {:type "text/javascript", :src (util/to-uri script)}])))
 
 (defn include-css
   "Include a list of external stylesheet files."

--- a/test/hiccup/page_test.clj
+++ b/test/hiccup/page_test.clj
@@ -74,7 +74,12 @@
          (list [:script {:type "text/javascript", :src (URI. "foo.js")}])))
   (is (= (include-js "foo.js" "bar.js")
          (list [:script {:type "text/javascript", :src (URI. "foo.js")}]
-               [:script {:type "text/javascript", :src (URI. "bar.js")}]))))
+               [:script {:type "text/javascript", :src (URI. "bar.js")}])))
+  (is (= (include-js "foo.js" "bar.js" {:src "baz.js" :defer true})
+         (list [:script {:type "text/javascript", :src (URI. "foo.js")}]
+               [:script {:type "text/javascript", :src (URI. "bar.js")}]
+               [:script {:type "text/javascript", :src (URI. "baz.js")
+                         :defer true}]))))
 
 (deftest include-css-test
   (is (= (include-css "foo.css")


### PR DESCRIPTION
This update modifies page/include-js accept maps as well as strings for the purpose of adding other element attributes to the script tag.