### PR TITLE
[util] Hint argument to avoid reflection.

### DIFF
--- a/src/hiccup/util.clj
+++ b/src/hiccup/util.clj
@@ -4,6 +4,8 @@
   (:import java.net.URI
            java.net.URLEncoder))
 
+(set! *warn-on-reflection* true)
+
 (def ^:dynamic ^:no-doc *html-mode* :xhtml)
 
 (def ^:dynamic ^:no-doc *escape-strings?* true)
@@ -98,7 +100,7 @@
 
 (extend-protocol URLEncode
   String
-  (url-encode [s] (URLEncoder/encode s *encoding*))
+  (url-encode [s] (URLEncoder/encode s (str *encoding*)))
   java.util.Map
   (url-encode [m]
     (str/join "&"


### PR DESCRIPTION
Hi, this is minor (obviously), but maybe fun.

Thanks as ever for `hiccup`, we render zillions of documents with it every day and it's truly joyful.

Before this change:
```
$ lein check
Compiling namespace hiccup.compiler
Reflection warning, hiccup/util.clj:101:19 - call to encode can't be resolved.
Compiling namespace hiccup.core
Compiling namespace hiccup.def
Compiling namespace hiccup.element
Compiling namespace hiccup.form
Compiling namespace hiccup.middleware
Compiling namespace hiccup.page
Compiling namespace hiccup.util
Reflection warning, hiccup/util.clj:101:19 - call to encode can't be resolved.
Compiling namespace hiccup2.core
```

After:
```
$ lein check
Compiling namespace hiccup.compiler
Compiling namespace hiccup.core
Compiling namespace hiccup.def
Compiling namespace hiccup.element
Compiling namespace hiccup.form
Compiling namespace hiccup.middleware
Compiling namespace hiccup.page
Compiling namespace hiccup.util
Compiling namespace hiccup2.core
```