### PR TITLE
Fix :class conversion in vector containing nil

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -77,7 +77,7 @@
   (cond
     (nil? class)    classes
     (string? class) (str classes " " class)
-    :else           (str classes " " (str/join " " (map name class)))))
+    :else           (str classes " " (str/join " " (keep #(some-> % name) class)))))
 
 (declare literal?)
 

--- a/test/hiccup/core_test.clj
+++ b/test/hiccup/core_test.clj
@@ -88,7 +88,9 @@
     (is (= (html [:div.foo {:class ["bar" "box"]} "baz"])
            "<div class=\"foo bar box\">baz</div>"))
     (is (= (html [:div.foo {:class [:bar :box]} "baz"])
-           "<div class=\"foo bar box\">baz</div>"))))
+           "<div class=\"foo bar box\">baz</div>"))
+    (is (= (html [:div.foo {:class [nil :bar nil]} "baz"])
+           "<div class=\"foo bar\">baz</div>"))))
 
 (deftest compiled-tags
   (testing "tag content can be vars"


### PR DESCRIPTION
Fixes #168.

Feel free to suggest a better commit message or further tests; I've just added a simple test here.