### PR TITLE
Fixes broken link to the `API Docs` in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following dependency to your `project.clj` file:
 ## Documentation
 
 * [Wiki](https://github.com/weavejester/hiccup/wiki)
-* [API Docs](http://weavejester.github.com/hiccup)
+* [API Docs](http://weavejester.github.io/hiccup)
     
 ## Syntax
 


### PR DESCRIPTION
Fixes broken link.
Kindly update it in the `About` section of the repo also.