### PR TITLE
Fix API docs URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following dependency to your `project.clj` file:
 ## Documentation
 
 * [Wiki](https://github.com/weavejester/hiccup/wiki)
-* [API Docs](http://weavejester.github.com/hiccup)
+* [API Docs](http://weavejester.github.io/hiccup)
     
 ## Syntax
 


### PR DESCRIPTION
The link for the API docs was broken. Using the new `github.io` domain.