### PR TITLE
Avoid reflection by adding type hints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,4 +15,5 @@
   {:dev {:dependencies [[criterium "0.4.4"]]}
    :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
    :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-   :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}})
+   :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
+  :global-vars {*warn-on-reflection* true})

--- a/src/hiccup/util.clj
+++ b/src/hiccup/util.clj
@@ -98,7 +98,7 @@
 
 (extend-protocol URLEncode
   String
-  (url-encode [s] (URLEncoder/encode s *encoding*))
+  (url-encode [s] (URLEncoder/encode ^String s ^String *encoding*))
   java.util.Map
   (url-encode [m]
     (str/join "&"


### PR DESCRIPTION
Makes it possible to use e.g. GraalVM