### PR TITLE
Performance optimizations

### DIFF
--- a/src/hiccup/util.clj
+++ b/src/hiccup/util.clj
@@ -80,7 +80,7 @@
 (defn escape-html
   "Change special characters into HTML character entities."
   [text]
-  (.. ^String (as-str text)
+  (.. ^String (to-str text)
     (replace "&"  "&amp;")
     (replace "<"  "&lt;")
     (replace ">"  "&gt;")
@@ -122,4 +122,3 @@
           (if (map? params)
             (str "?" (url-encode params))
             params)))))
-


### PR DESCRIPTION
## Introduction

When I set out to measure the number of requests per second from my server—specifically, those outputting a small <em>HTML</em> string based on <em>hiccup</em> — I was surprised.

Despite the hiccup content being very small, the response using the hiccup->html conversion was discernibly slower than the response with the identical HTML string, showing a disparity of 24k req/sec versus 40k req/sec. 

Upon delving into the hiccup source code, I identified several factors that significantly hampered the processing speed.

## Benchmarking & Profiling

Initially, I decided to estimate the speed of execution with <em>criterium</em>. On my computer, I obtained the following results:

<details>
  <summary>Case №1</summary>
  
``` clj
(def hiccup
  [:span "hello"])

(criterium.core/bench
  (hiccup2.core/html hiccup))
  
;; Evaluation count : 25789500 in 60 samples of 429825 calls.
;;              Execution time mean : 2.330993 µs
;;     Execution time std-deviation : 41.090772 ns
;;    Execution time lower quantile : 2.303320 µs ( 2.5%)
;;    Execution time upper quantile : 2.373499 µs (97.5%)
;;                    Overhead used : 7.614148 ns

;; Found 6 outliers in 60 samples (10.0000 %)
;; 	low-severe	 1 (1.6667 %)
;; 	low-mild	 4 (6.6667 %)
;; 	high-mild	 1 (1.6667 %)
;;  Variance from outliers : 6.2942 % Variance is slightly inflated by outliers
```
  
</details>

<details>
  <summary>Case №2</summary>
  
``` clj
(def hiccup
  [:span#foo.bar.baz {:id "foo" :class "qux" :styles {:a 1 :b 2}} "hello"])

(criterium.core/bench
  (hiccup2.core/html hiccup))
  
;; Evaluation count : 8239680 in 60 samples of 137328 calls.
;;              Execution time mean : 7.269213 µs
;;     Execution time std-deviation : 145.634319 ns
;;    Execution time lower quantile : 7.167641 µs ( 2.5%)
;;    Execution time upper quantile : 7.541402 µs (97.5%)
;;                    Overhead used : 7.614148 ns

;; Found 5 outliers in 60 samples (8.3333 %)
;; 	low-severe	 2 (3.3333 %)
;; 	low-mild	 3 (5.0000 %)
;;  Variance from outliers : 9.3512 % Variance is slightly inflated by outliers
```
  
</details>

<details>
  <summary>Case №3</summary>
  
``` clj
(def hiccup
  [:html
   [:head
    [:title "Title"]]
   [:body
    [:span "foo"]
    [:span#id "foo"]
    [:span#id.class1.class2 "foo"]
    [:span#id.class1.class2 {:id "id"} "foo"]
    [:span#id.class1.class2 {:class "class3"} "foo"]
    [:span#id.class1.class2 {:styles {:a 1 :b 2}} "foo"]
    (for [i [1 2 3 4]]
      [:span i])]])

(criterium.core/bench
  (hiccup2.core/html hiccup))
  
;; Evaluation count : 1288140 in 60 samples of 21469 calls.
;;              Execution time mean : 46.760425 µs
;;     Execution time std-deviation : 837.581889 ns
;;    Execution time lower quantile : 46.220047 µs ( 2.5%)
;;    Execution time upper quantile : 47.416694 µs (97.5%)
;;                    Overhead used : 7.614148 ns

;; Found 2 outliers in 60 samples (3.3333 %)
;; 	low-severe	 1 (1.6667 %)
;; 	low-mild	 1 (1.6667 %)
;;  Variance from outliers : 7.7697 % Variance is slightly inflated by outliers
```
  
</details>

After that I decided to do the profiling using clj-async-profiler.  I discovered numerous calls where there was a cast to `clojure.lang.RT.LazySeq.seq` and a call to `clojure.lang.RestFn.invoke`. These calls are highlighted in dark pink in the picture.
<details>
  <summary>Profiling report</summary>
  <img width="1109" alt="image" src="https://user-images.githubusercontent.com/43318093/272086113-9796e69e-571f-4c82-8b8b-61172e337f4e.png">

</details>
  
## Optimization Changes

1. [Removed unnecessary LazySeq.seq and RestFn.invoke calls](https://github.com/Panthevm/hiccup/commit/90d99cb80fae7d404726b1d8e295eae4e3985931)
   - hiccup.util/as-str [& xs] `->` hiccup.util/to-str [x]
   - clojure.core/str [x & ys] `->` hiccup.util/build-string [& strs] <em>(macro)</em>
   - map + apply str `->` StringBuilder + hiccup.util/fast-run
   - hiccup.compiler#re-matches `->` hiccup.compiler/parse-tag
2. [Optimized node tag parsing](https://github.com/Panthevm/hiccup/commit/f22c30e44252147d09f049baedf308b3d0ffd0a2)
   - hiccup.compiler#re-matches `->` hiccup.compiler/parse-tag
3. [Skip attribute processing when absent](https://github.com/Panthevm/hiccup/commit/53d6a9811e9ebb29adeffe8be231e910a93964df)


## Results

<details>
  <summary>Case №1 (2.4µs -> 600ns)</summary>
  
``` clj
(def hiccup
  [:span "hello"])

(criterium.core/bench
  (hiccup2.core/html hiccup))
  
;; Evaluation count : 100645620 in 60 samples of 1677427 calls.
;;              Execution time mean : 598.744611 ns
;;     Execution time std-deviation : 11.053241 ns
;;    Execution time lower quantile : 566.805045 ns ( 2.5%)
;;    Execution time upper quantile : 614.233694 ns (97.5%)
;;                    Overhead used : 8.220649 ns

;; Found 8 outliers in 60 samples (13.3333 %)
;; 	low-severe	 4 (6.6667 %)
;; 	low-mild	 2 (3.3333 %)
;; 	high-mild	 2 (3.3333 %)
;;  Variance from outliers : 7.8027 % Variance is slightly inflated by outliers

```
  
</details>

<details>
  <summary>Case №2 (7.3 µs -> 2.9 µs)</summary>
  
``` clj
(def hiccup
  [:span#foo.bar.baz {:id "foo" :class "qux" :styles {:a 1 :b 2}} "hello"])

(criterium.core/bench
  (hiccup2.core/html hiccup))
  
;; Evaluation count : 20125980 in 60 samples of 335433 calls.
;;              Execution time mean : 2.942334 µs
;;     Execution time std-deviation : 26.560566 ns
;;    Execution time lower quantile : 2.911728 µs ( 2.5%)
;;    Execution time upper quantile : 3.007485 µs (97.5%)
;;                    Overhead used : 8.220649 ns

;; Found 5 outliers in 60 samples (8.3333 %)
;; 	low-severe	 5 (8.3333 %)
;;  Variance from outliers : 1.6389 % Variance is slightly inflated by outliers

```
  
</details>

<details>
  <summary>Case №3 (46.8µs -> 18 µs)</summary>
  
``` clj
(def hiccup
  [:html
   [:head
    [:title "Title"]]
   [:body
    [:span "foo"]
    [:span#id "foo"]
    [:span#id.class1.class2 "foo"]
    [:span#id.class1.class2 {:id "id"} "foo"]
    [:span#id.class1.class2 {:class "class3"} "foo"]
    [:span#id.class1.class2 {:styles {:a 1 :b 2}} "foo"]
    (for [i [1 2 3 4]]
      [:span i])]])

(criterium.core/bench
  (hiccup2.core/html hiccup))
  
;; Evaluation count : 3370440 in 60 samples of 56174 calls.
;;              Execution time mean : 18.236171 µs
;;     Execution time std-deviation : 383.229484 ns
;;    Execution time lower quantile : 17.635168 µs ( 2.5%)
;;    Execution time upper quantile : 18.784032 µs (97.5%)
;;                    Overhead used : 8.220649 ns

;; Found 1 outliers in 60 samples (1.6667 %)
;; 	low-severe	 1 (1.6667 %)
;;  Variance from outliers : 9.4103 % Variance is slightly inflated by outliers

```
  
</details>

<details>
  <summary>Profiling report</summary>
  <img width="1113" alt="image" src="https://user-images.githubusercontent.com/43318093/272094998-7a98aaaf-df95-462b-b95a-cb508a2f059d.png">

</details>

### Questions
- Why are we sorting the attributes and the style attribute? Is this just for test output?
- Why do we escaping HTML text/attributes by default? Isn't this a complex operation?