### PR TITLE
Fix literal child elements being escaped

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -356,11 +356,11 @@
 (defmethod compile-element ::default
   [element]
   `(render-element
-     [~(first element)
-      ~@(for [x (rest element)]
-          (if (vector? x)
-            (compile-element x)
-            x))]))
+    [~(first element)
+     ~@(for [x (rest element)]
+         (if (vector? x)
+           (util/raw-string (compile-element x))
+           x))]))
 
 (defn- compile-seq
   "Compile a sequence of data-structures into HTML."


### PR DESCRIPTION
Fixes `(html [(identity :p) [:span "x"]])` producing `"<p>&lt;span&gt;x&lt;/span&gt;</p>"` instead of `"<p><span>x</span></p>"`

I also noticed that `element-compile-strategy` returned `::default`, but `compile-element` used `:default` (the default dispatching value for multimethods). Now they both use the same dispatching value.