### PR TITLE
Evaluate vector and map attributes

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -166,7 +166,7 @@
        content])))
 
 (defn normalize-element
-  "Ensure an element vector is of the form [tag-name attrs content]." 
+  "Ensure an element vector is of the form [tag-name attrs content]."
   [tag-content]
   (normalize-element* tag-content merge-attributes))
 
@@ -217,13 +217,20 @@
       (and (seq? expr)
            (not= (first expr) `quote))))
 
+(defn- literal?
+  "True if x is a literal value that can be rendered as-is."
+  [x]
+  (and (not (unevaluated? x))
+       (or (not (or (vector? x) (map? x)))
+           (every? literal? x))))
+
 (defn compile-attr-map
   "Returns an unevaluated form that will render the supplied map as HTML
   attributes."
   [attrs]
-  (if (some unevaluated? (mapcat identity attrs))
-    `(render-attr-map ~attrs)
-    (render-attr-map attrs)))
+  (if (every? literal? (mapcat identity attrs))
+    (render-attr-map attrs)
+    `(render-attr-map ~attrs)))
 
 (defn- form-name
   "Get the name of the supplied form."
@@ -275,13 +282,6 @@
   [x type]
   (if-let [hint (-> x meta :tag)]
     (isa? (eval hint) type)))
-
-(defn- literal?
-  "True if x is a literal value that can be rendered as-is."
-  [x]
-  (and (not (unevaluated? x))
-       (or (not (or (vector? x) (map? x)))
-           (every? literal? x))))
 
 (defn- not-implicit-map?
   "True if we can infer that x is not a map."

--- a/test/hiccup2/core_test.clj
+++ b/test/hiccup2/core_test.clj
@@ -7,7 +7,7 @@
   (testing "html returns a RawString"
     (is (util/raw-string? (html [:div]))))
   (testing "converting to string"
-    (= (str (html [:div])) "<div></div>")))
+    (is (= (str (html [:div])) "<div></div>"))))
 
 (deftest tag-names
   (testing "basic tags"
@@ -115,6 +115,15 @@
            "<img src=\"/foo/bar\" />"))
     (is (= (str (html [:div {:id (str "a" "b")} (str "foo")]))
            "<div id=\"ab\">foo</div>")))
+  (testing "vector attributes are evaluated"
+    (let [x "bar"]
+      (is (= (str (html [:span {:class ["foo" x]}]))
+             "<span class=\"foo bar\"></span>"))))
+  (testing "map attributes are evaluated"
+    (let [color "red"
+          bg-color :blue]
+      (is (= (str (html [:span {:style {:background-color bg-color, :color color}} "foo"]))
+             "<span style=\"background-color:blue;color:red;\">foo</span>"))))
   (testing "type hints"
     (let [string "x"]
       (is (= (str (html [:span ^String string])) "<span>x</span>"))))


### PR DESCRIPTION
Fixes a bug where the compiler emits unevaluated forms within vector or map attributes:

```clojure
(require '[hiccup2.core :refer [html]])

(defn my-button [{:keys [color]} text]
  (html [:div {:class ["button" (str "bg-" (name color))]} text]))

(str (my-button {:color :green} "OK"))
```

Before:

```clojure
"<div class=\"button (str &quot;bg-&quot; (name color))\">OK</div>"
```

With this PR:

```clojure
"<div class=\"button bg-green\">OK</div>"
```