### PR TITLE
Use standard library functions where possible

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -45,7 +45,7 @@
       1 (let [arg (first strs)]
           (if (string? arg)
             arg
-            `(String/valueOf (or ~arg ""))))
+            `(str (or ~arg ""))))
       `(let [~w (StringBuilder.)]
          ~@(map (fn [arg]
                   (if (string? arg)

--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -117,15 +117,15 @@
   (let [id-index    (let [index (.indexOf tag "#")] (when (pos? index) index))
         class-index (let [index (.indexOf tag ".")] (when (pos? index) index))]
     [(cond
-       id-index    (.substring tag 0 id-index)
-       class-index (.substring tag 0 class-index)
+       id-index    (subs tag 0 id-index)
+       class-index (subs tag 0 class-index)
        :else tag)
      (when id-index
        (if class-index
-         (.substring tag (unchecked-inc-int id-index) class-index)
-         (.substring tag (unchecked-inc-int id-index))))
+         (subs tag (unchecked-inc-int id-index) class-index)
+         (subs tag (unchecked-inc-int id-index))))
      (when class-index
-       (.substring tag (unchecked-inc-int class-index)))]))
+       (subs tag (unchecked-inc-int class-index)))]))
 
 (defn merge-classes [class classes]
   (cond

--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -112,10 +112,16 @@
   (or content
       (and (html-mode?) (not (void-tags tag)))))
 
+(def str-index-of 
+  (or (resolve 'str/index-of)
+      (fn [^String tag ^String value] 
+        (let [index (.indexOf tag value)]
+          (when (pos? index) 
+            index)))))
 
-(defn- parse-tag [^String tag]
-  (let [id-index    (let [index (.indexOf tag "#")] (when (pos? index) index))
-        class-index (let [index (.indexOf tag ".")] (when (pos? index) index))]
+(defn- parse-tag [tag]
+  (let [id-index (str-index-of tag "#")
+        class-index (str-index-of tag ".")]
     [(cond
        id-index    (subs tag 0 id-index)
        class-index (subs tag 0 class-index)


### PR DESCRIPTION
This commit removes some unnecessary interop.

- `.substring` to `subs`
- `.indexOf` to `clojure.string/index-of` (with backwards compatibility for older clojure versions <1.8)
- Replace unnecessary `String/valueOf with` `str` ([reasoning here](https://github.com/weavejester/hiccup/commit/00ddf9996eca193606763a071334bfa1fcc0fd20#r147843229))

It is a first step towards resolving issues https://github.com/weavejester/hiccup/issues/184 and https://github.com/weavejester/hiccup/issues/127 less

I've left the StringBuilder interop for now, as it might have performance benefits and a (good) patch would be more involved.