### PR TITLE
Fix: Compiler emits unevaluated forms when the tag is non-literal

### DIFF
--- a/src/hiccup/compiler.clj
+++ b/src/hiccup/compiler.clj
@@ -367,7 +367,7 @@
     [~(first element)
      ~@(for [x (rest element)]
          (if (vector? x)
-           (util/raw-string (compile-element x))
+           `(util/raw-string ~(compile-element x))
            x))]))
 
 (defn- compile-seq

--- a/test/hiccup/compiler_test.clj
+++ b/test/hiccup/compiler_test.clj
@@ -103,15 +103,19 @@
   (testing "runtime tag with child elements"
     (is (= (str (html {:mode :xhtml} [(identity :p) [:span "x"]]))
            (str (html {:mode :xhtml} [(identity :p) (identity [:span "x"])]))
+           (str (html {:mode :xhtml} [(identity :p) [:span (identity "x")]]))
            "<p><span>x</span></p>"))
     (is (= (str (html {:mode :html} [(identity :p) [:span "x"]]))
            (str (html {:mode :html} [(identity :p) (identity [:span "x"])]))
+           (str (html {:mode :html} [(identity :p) [:span (identity "x")]]))
            "<p><span>x</span></p>"))
     (is (= (str (html {:mode :xml} [(identity :p) [:span "x"]]))
            (str (html {:mode :xml} [(identity :p) (identity [:span "x"])]))
+           (str (html {:mode :xml} [(identity :p) [:span (identity "x")]]))
            "<p><span>x</span></p>"))
     (is (= (str (html {:mode :sgml} [(identity :p) [:span "x"]]))
            (str (html {:mode :sgml} [(identity :p) (identity [:span "x"])]))
+           (str (html {:mode :sgml} [(identity :p) [:span (identity "x")]]))
            "<p><span>x</span></p>")))
 
   (testing "compiles literal child elements"


### PR DESCRIPTION
Compiling an element whose tag is non-literal (e.g. a symbol) and that has non-literal vector children, led to the child form to be emitted unevaluated.

Reproducing example:

```clojure
(let [tag :p, text "x"]
  (str (hiccup/html [tag [:span text]])))
;; => "<p>(clojure.core/let [attrs_or_content__74605 text attrs?__74606 (clojure.core/map? attrs_or_content__74605) content?__74607 (clojure.core/and (clojure.core/not attrs?__74606) (clojure.core/some? attrs_or_content__74605))] (hiccup.compiler/build-string \"<\" \"span\" (if attrs?__74606 (hiccup.compiler/render-attr-map (clojure.core/merge {} attrs_or_content__74605)) \"\") \">\" (clojure.core/when content?__74607 (hiccup.compiler/render-html attrs_or_content__74605)) \"</span>\"))</p>"
```

This seems to be a regression from #207.